### PR TITLE
DDF-1967

### DIFF
--- a/catalog/registry/catalog-registry-common/src/main/java/ddf/catalog/registry/common/metacard/RegistryObjectMetacardType.java
+++ b/catalog/registry/catalog-registry-common/src/main/java/ddf/catalog/registry/common/metacard/RegistryObjectMetacardType.java
@@ -13,6 +13,8 @@
  */
 package ddf.catalog.registry.common.metacard;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import ddf.catalog.data.AttributeDescriptor;
@@ -71,6 +73,19 @@ public class RegistryObjectMetacardType extends MetacardTypeImpl {
 
     public static final String REGISTRY_BASE_URL = "registry-base-url";
 
+    public static final String REGISTRY_LOCAL_NODE = "registry-local-node";
+
+    public static final Set<String> TRANSIENT_ATTRIBUTES;
+
+    static {
+        final Set<String> transientAttributes = new HashSet<>();
+        transientAttributes.add(REGISTRY_IDENTITY_NODE);
+        transientAttributes.add(REGISTRY_LOCAL_NODE);
+        transientAttributes.add(PUBLISHED_LOCATIONS);
+
+        TRANSIENT_ATTRIBUTES = Collections.unmodifiableSet(transientAttributes);
+    }
+
     public RegistryObjectMetacardType() {
         this(REGISTRY_METACARD_TYPE_NAME, null);
     }
@@ -110,6 +125,7 @@ public class RegistryObjectMetacardType extends MetacardTypeImpl {
         addQueryableString(SERVICE_BINDING_TYPES, true);
         addQueryableString(REGISTRY_ID, false);
         addQueryableBoolean(REGISTRY_IDENTITY_NODE, false);
+        addQueryableBoolean(REGISTRY_LOCAL_NODE, false);
         addQueryableString(REGISTRY_BASE_URL, false);
         addQueryableString(PUBLISHED_LOCATIONS, true);
     }

--- a/catalog/registry/catalog-registry-cswinputtransformer/pom.xml
+++ b/catalog/registry/catalog-registry-cswinputtransformer/pom.xml
@@ -57,7 +57,6 @@
             <groupId>ddf.platform</groupId>
             <artifactId>platform-parser-xml</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.registry</groupId>
@@ -87,7 +86,7 @@
                         <Export-Package/>
                         <Embed-Dependency>
                             catalog-registry-common,
-                            catalog-core-api-impl,
+                            catalog-core-api-impl;scope=!test,
                             jaxb2-basics-runtime,
                             ogc-tools-gml-jts
                         </Embed-Dependency>

--- a/catalog/registry/catalog-registry-federationadminapi/pom.xml
+++ b/catalog/registry/catalog-registry-federationadminapi/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>registry</artifactId>
+        <groupId>ddf.catalog.registry</groupId>
+        <version>2.9.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>catalog-registry-federationadminapi</artifactId>
+    <name>DDF :: Catalog :: Registry :: Federation Admin Api</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.registry</groupId>
+            <artifactId>catalog-registry-federationadminservice</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/registry/catalog-registry-federationadminapi/src/main/java/ddf/catalog/registry/federationadmin/FederationAdminMBean.java
+++ b/catalog/registry/catalog-registry-federationadminapi/src/main/java/ddf/catalog/registry/federationadmin/FederationAdminMBean.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.registry.federationadmin;
+
+import java.util.List;
+import java.util.Map;
+
+import ddf.catalog.registry.federationadmin.service.FederationAdminException;
+
+/**
+ * This is the external facing interface for the FederationAdminService. This is what should be used by the UI,
+ * for example, to interact with the FederationAdminService.
+ */
+public interface FederationAdminMBean {
+    String OBJECT_NAME = "ddf.catalog.registy:type=FederationAdminMBean";
+
+    /**
+     * Create a local entry in the registry catalog for the given object map.
+     * The map will be converted to a {@link RegistryPackageType} using the {@link RegistryPackageWebConverter}.
+     * The resulting {@link RegistryPackageType} will be passed to {@link FederationAdminService#addLocalEntry}
+     * to create the entry.
+     *
+     * @param RegistryObjectMap A map of the registry object to create
+     * @return Id of the created metacard.
+     * @throws FederationAdminException Passes exception thrown by FederationAdminServiceImpl
+     */
+    String createLocalEntry(Map<String, Object> registryObjectMap) throws FederationAdminException;
+
+    /**
+     * Create a local entry in the registry catalog for the given string.
+     * The String provided is an Base64 encoded representation of a registry package xml.
+     * The RegistryTransformer transforms the Base64 decode stream into a registry metacard.
+     *
+     * @param base64EncodedXmlString Base64 encoded registry package xml.
+     * @return Id of the created metacard
+     * @throws FederationAdminException If Base64 decoding of the string fails
+     *                                  If the RegistryTransformer can't convert the stream into a metacard
+     *                                  Passes exceptions thrown by FederationAdminServiceImpl
+     */
+    String createLocalEntry(String base64EncodedXmlString) throws FederationAdminException;
+
+    /**
+     * Update a local entry in the registry catalog for the given object map.
+     * The map will be converted to a {@link RegistryPackageType} using the {@link RegistryPackageWebConverter}.
+     * The resulting {@link RegistryPackageType} will be passed to {@link FederationAdminService#addLocalEntry}
+     * to update the entry.
+     *
+     * @param registryObjectMap A map of the registry object to update
+     * @throws FederationAdminException Passes exception thrown byFederationAdminServiceImpl
+     */
+    void updateLocalEntry(Map<String, Object> registryObjectMap) throws FederationAdminException;
+
+    /**
+     * Deletes a local entry in the registry catalog for each of the ids provided.
+     *
+     * @param ids List of registry ids to be deleted
+     * @throws FederationAdminException Passes exception thrown byFederationAdminServiceImpl
+     */
+    void deleteLocalEntry(List<String> ids) throws FederationAdminException;
+
+    /**
+     * Returns a Map of RegistryPackage objects as converted using {@code RegistryPackageWebConverter}
+     *
+     * @return Map<String, Object>
+     * @throws FederationAdminException Passes exception thrown byFederationAdminServiceImpl
+     */
+    Map<String, Object> getLocalNodes() throws FederationAdminException;
+}

--- a/catalog/registry/catalog-registry-federationadminimpl/pom.xml
+++ b/catalog/registry/catalog-registry-federationadminimpl/pom.xml
@@ -15,18 +15,23 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>ddf.catalog.registry</groupId>
         <artifactId>registry</artifactId>
         <version>2.9.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>catalog-registry-federationadminserviceimpl</artifactId>
-    <name>DDF :: Catalog :: Registry :: Federation Admin Service Impl</name>
+    <artifactId>catalog-registry-federationadminimpl</artifactId>
+    <name>DDF :: Catalog :: Registry :: Federation Admin Impl</name>
     <packaging>bundle</packaging>
 
     <dependencies>
+        <dependency>
+            <groupId>ddf.catalog.registry</groupId>
+            <artifactId>catalog-registry-federationadminapi</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>ddf.catalog.registry</groupId>
             <artifactId>catalog-registry-federationadminservice</artifactId>
@@ -34,22 +39,17 @@
         </dependency>
         <dependency>
             <groupId>ddf.catalog.registry</groupId>
-            <artifactId>catalog-registry-api</artifactId>
+            <artifactId>catalog-registry-cswinputtransformer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-standardframework</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>ddf.catalog.registry</groupId>
             <artifactId>catalog-registry-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.registry</groupId>
-            <artifactId>catalog-registry-schema-bindings</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>ddf.catalog.registry</groupId>
-            <artifactId>catalog-registry-cswinputtransformer</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -67,22 +67,7 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ddf.platform</groupId>
-            <artifactId>platform-parser-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codice.thirdparty</groupId>
-            <artifactId>geotools-suite</artifactId>
-            <version>${org.geotools.bundle.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-ext</artifactId>
-        </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>
@@ -95,8 +80,7 @@
                         <Bundle-Name>${project.name}</Bundle-Name>
                         <Embed-Dependency>
                             catalog-core-api-impl;scope=!test,
-                            ddf-security-common,
-                            catalog-registry-common
+                            ddf-security-common
                         </Embed-Dependency>
                         <Import-Package>
                             !org.codice.ddf.platform.util.http,
@@ -130,17 +114,17 @@
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.65</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.70</minimum>
+                                            <minimum>0.47</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.90</minimum>
+                                            <minimum>0.92</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/registry/catalog-registry-federationadminimpl/src/main/java/ddf/catalog/registry/federationadmin/converter/RegistryPackageWebConverter.java
+++ b/catalog/registry/catalog-registry-federationadminimpl/src/main/java/ddf/catalog/registry/federationadmin/converter/RegistryPackageWebConverter.java
@@ -1,0 +1,1809 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.registry.federationadmin.converter;
+
+import static org.joda.time.format.ISODateTimeFormat.dateOptionalTimeParser;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.JAXBElement;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+
+import net.opengis.cat.wrs.v_1_0_2.AnyValueType;
+import net.opengis.gml.v_3_1_1.DirectPositionType;
+import net.opengis.gml.v_3_1_1.PointType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.AssociationType1;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ClassificationType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.EmailAddressType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExternalIdentifierType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExtrinsicObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.InternationalStringType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.LocalizedStringType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ObjectFactory;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.OrganizationType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.PersonNameType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.PersonType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.PostalAddressType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectListType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ServiceBindingType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ServiceType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.SpecificationLinkType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.TelephoneNumberType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ValueListType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.VersionInfoType;
+
+public class RegistryPackageWebConverter {
+
+    private static final String ID_KEY = "id";
+
+    private static final String HOME_KEY = "home";
+
+    private static final String OBJECT_TYPE_KEY = "objectType";
+
+    private static final String NAME = "name";
+
+    private static final String NAME_KEY = "Name";
+
+    private static final String DESCRIPTION_KEY = "Description";
+
+    private static final String VERSION_INFO_KEY = "VersionInfo";
+
+    private static final String SLOT = "Slot";
+
+    private static final String VALUE = "value";
+
+    private static final String SLOT_TYPE = "slotType";
+
+    private static final String SERVICE_KEY = "Service";
+
+    private static final String REGISTRY_OBJECT_LIST_KEY = "RegistryObjectList";
+
+    private static final String SERVICE_BINDING_KEY = "ServiceBinding";
+
+    private static final String POINT_KEY = "Point";
+
+    private static final String SRS_DIMENSION = "srsDimension";
+
+    private static final String SRS_NAME = "srsName";
+
+    private static final String POSITION = "pos";
+
+    private static final String XML_DATE_TIME_TYPE = ":dateTime";
+
+    private static final String XML_GEO_TYPE = ":GM_Point";
+
+    private static final String ADDRESS_CITY = "city";
+
+    private static final String ADDRESS_COUNTRY = "country";
+
+    private static final String ADDRESS_POSTAL_CODE = "postalCode";
+
+    private static final String ADDRESS_STATE_OR_PROVINCE = "stateOrProvince";
+
+    private static final String ADDRESS_STREET = "street";
+
+    private static final String ADDRESS_KEY = "Address";
+
+    private static final String ORGANIZATION_KEY = "Organization";
+
+    private static final String PHONE_AREA_CODE = "areaCode";
+
+    private static final String PHONE_NUMBER = "number";
+
+    private static final String PHONE_EXTENSION = "extension";
+
+    private static final String TELEPHONE_KEY = "TelephoneNumber";
+
+    private static final String EMAIL_ADDRESS = "address";
+
+    private static final String EMAIL_ADDRESS_KEY = "EmailAddress";
+
+    private static final String PARENT_KEY = "parent";
+
+    private static final String PERSON_FIRST_NAME = "firstName";
+
+    private static final String PERSON_MIDDLE_NAME = "middleName";
+
+    private static final String PERSON_LAST_NAME = "lastName";
+
+    private static final String PERSON_NAME_KEY = "PersonName";
+
+    private static final String PERSON_KEY = "Person";
+
+    private static final String ASSOCIATION_TYPE = "associationType";
+
+    private static final String ASSOCIATION_SOURCE_OBJECT = "sourceObject";
+
+    private static final String ASSOCIATION_TARGET_OBJECT = "targetObject";
+
+    private static final String ASSOCIATION_KEY = "Association";
+
+    private static final String EXT_ID_IDENTIFICATION_SCHEME = "identificationScheme";
+
+    private static final String EXT_ID_REGISTRY_OBJECT = "registryObject";
+
+    private static final String EXT_ID_VALUE = "value";
+
+    private static final String EXTERNAL_IDENTIFIER_KEY = "ExternalIdentifier";
+
+    private static final String EXTRINSIC_OBJECT_CONTENT_VERSION = "contentVersion";
+
+    private static final String EXTRINSIC_OBJECT_OPAQUE = "opaque";
+
+    private static final String EXTRINSIC_OBJECT_MIME_TYPE = "mimeType";
+
+    private static final String EXTRINSIC_OBJECT_KEY = "ExtrinsicObject";
+
+    private static final String LID_KEY = "Lid";
+
+    private static final String STATUS_KEY = "Status";
+
+    private static final ObjectFactory RIM_FACTORY = new ObjectFactory();
+
+    private static final net.opengis.cat.wrs.v_1_0_2.ObjectFactory WRS_FACTORY =
+            new net.opengis.cat.wrs.v_1_0_2.ObjectFactory();
+
+    private static final net.opengis.gml.v_3_1_1.ObjectFactory GML_FACTORY =
+            new net.opengis.gml.v_3_1_1.ObjectFactory();
+
+    private static final String BINDING_ACCESS_URI = "accessUri";
+
+    private static final String BINDING_SERVICE = "service";
+
+    private static final String BINDING_TARGET_BINDING = "targetBinding";
+
+    private static final String SPECIFICATION_LINK_SERVICE_BINDING = "serviceBinding";
+
+    private static final String SPECIFICATION_LINK_SPECIFICATION_OBJECT = "specificationObject";
+
+    private static final String SPECIFICATION_LINK_USAGE_DESCRIPTION = "usageDescription";
+
+    private static final String SPECIFICATION_LINK_KEY = "SpecificationLink";
+
+    private static final String SPECIFICATION_LINK_USAGE_PARAMETERS = "usageParameters";
+
+    private static final String PRIMARY_CONTACT = "primaryContact";
+
+    private static final String ADDRESS_STREET_NUMBER = "streetNumber";
+
+    private static final String EMAIL_TYPE = "type";
+
+    private static final String PHONE_COUNTRY_CODE = "countryCode";
+
+    private static final String PHONE_TYPE = "phoneType";
+
+    private static final String CLASSIFICATION_NODE = "classificationNode";
+
+    private static final String CLASSIFIED_OBJECT = "classifiedObject";
+
+    private static final String CLASSIFICATION_SCHEME = "classificationScheme";
+
+    private static final String NODE_REPRESENTATION = "nodeRepresentation";
+
+    private static final String CLASSIFICATION_KEY = "Classification";
+
+    private RegistryPackageWebConverter() {
+    }
+
+    public static Map<String, Object> getRegistryObjectWebMap(RegistryObjectType registryObject) {
+        Map<String, Object> registryObjectMap = new HashMap<>();
+
+        putTopLevel(registryObject, registryObjectMap);
+
+        if (registryObject instanceof RegistryPackageType) {
+            putRegistryPackage((RegistryPackageType) registryObject, registryObjectMap);
+        } else if (registryObject instanceof ExtrinsicObjectType) {
+            putExtrinsicObject((ExtrinsicObjectType) registryObject, registryObjectMap);
+        } else if (registryObject instanceof ServiceType) {
+            putRegistryService((ServiceType) registryObject, registryObjectMap);
+        } else if (registryObject instanceof OrganizationType) {
+            putRegistryOrganization((OrganizationType) registryObject, registryObjectMap);
+        } else if (registryObject instanceof PersonType) {
+            putRegistryPerson((PersonType) registryObject, registryObjectMap);
+        } else if (registryObject instanceof AssociationType1) {
+            putRegistryAssociation((AssociationType1) registryObject, registryObjectMap);
+        }
+
+        return registryObjectMap;
+    }
+
+    public static RegistryPackageType getRegistryPackageFromWebMap(
+            Map<String, Object> registryMap) {
+        if (registryMap == null) {
+            return null;
+        }
+
+        RegistryPackageType registryPackage = RIM_FACTORY.createRegistryPackageType();
+
+        populateTopLevel(registryMap, registryPackage);
+
+        if (registryMap.containsKey(REGISTRY_OBJECT_LIST_KEY)) {
+            populateRegistryObjectList((Map<String, Object>) registryMap.get(
+                    REGISTRY_OBJECT_LIST_KEY), registryPackage);
+        }
+
+        if (isRegistryPackageEmpty(registryPackage)) {
+            registryPackage = null;
+        }
+
+        return registryPackage;
+    }
+
+    private static void putTopLevel(RegistryObjectType registryObject,
+            Map<String, Object> registryMap) {
+
+        putGeneralInfo(registryObject, registryMap);
+    }
+
+    private static void populateTopLevel(Map<String, Object> registryMap,
+            RegistryObjectType registryPackage) {
+        populateGeneralInfo(registryMap, registryPackage);
+    }
+
+    private static void putRegistryPackage(RegistryPackageType registryPackage,
+            Map<String, Object> registryMap) {
+        if (registryPackage.isSetRegistryObjectList()) {
+            putRegistryObjectList(registryPackage.getRegistryObjectList(), registryMap);
+        }
+
+        if (registryPackage.isSetSlot()) {
+            putSlotList(registryPackage.getSlot(), registryMap);
+        }
+    }
+
+    private static void putRegistryObjectList(RegistryObjectListType registryObjects,
+            Map<String, Object> registryObjectMap) {
+
+        Map<String, Object> registryObjectListMap = new HashMap<>();
+
+        for (JAXBElement identifiable : registryObjects.getIdentifiable()) {
+            RegistryObjectType registryObject = (RegistryObjectType) identifiable.getValue();
+
+            if (registryObject instanceof ExtrinsicObjectType) {
+                putExtrinsicObject((ExtrinsicObjectType) registryObject, registryObjectListMap);
+            } else if (registryObject instanceof ServiceType) {
+                putRegistryService((ServiceType) registryObject, registryObjectListMap);
+            } else if (registryObject instanceof OrganizationType) {
+                putRegistryOrganization((OrganizationType) registryObject, registryObjectListMap);
+            } else if (registryObject instanceof PersonType) {
+                putRegistryPerson((PersonType) registryObject, registryObjectListMap);
+            } else if (registryObject instanceof AssociationType1) {
+                putRegistryAssociation((AssociationType1) registryObject, registryObjectListMap);
+            }
+
+            if (!registryObjectListMap.isEmpty()) {
+                registryObjectMap.put(REGISTRY_OBJECT_LIST_KEY, registryObjectListMap);
+            }
+        }
+
+    }
+
+    private static void populateRegistryObjectList(Map<String, Object> rolMap,
+            RegistryPackageType registryPackage) {
+        if (rolMap.isEmpty()) {
+            return;
+        }
+
+        RegistryObjectListType registryObjectList = RIM_FACTORY.createRegistryObjectListType();
+
+        if (rolMap.containsKey(EXTRINSIC_OBJECT_KEY)) {
+            populateROLWithExtrinsicObject((List<Map<String, Object>>) rolMap.get(
+                    EXTRINSIC_OBJECT_KEY), registryObjectList);
+
+        }
+
+        if (rolMap.containsKey(SERVICE_KEY)) {
+            populateROLWithService((List<Map<String, Object>>) rolMap.get(SERVICE_KEY),
+                    registryObjectList);
+        }
+
+        if (rolMap.containsKey(ORGANIZATION_KEY)) {
+            populateROLWithOrganization((List<Map<String, Object>>) rolMap.get(ORGANIZATION_KEY),
+                    registryObjectList);
+        }
+
+        if (rolMap.containsKey(PERSON_KEY)) {
+            populateROLWithPerson((List<Map<String, Object>>) rolMap.get(PERSON_KEY),
+                    registryObjectList);
+        }
+
+        if (rolMap.containsKey(ASSOCIATION_KEY)) {
+            populateROLWithAssociation((List<Map<String, Object>>) rolMap.get(ASSOCIATION_KEY),
+                    registryObjectList);
+        }
+
+        if (CollectionUtils.isNotEmpty(registryObjectList.getIdentifiable())) {
+            registryPackage.setRegistryObjectList(registryObjectList);
+        }
+
+    }
+
+    private static void putExtrinsicObject(ExtrinsicObjectType extrinsicObject,
+            Map<String, Object> registryObjectListMap) {
+        if (extrinsicObject == null) {
+            return;
+        }
+
+        Map<String, Object> extrinsicObjectMap = new HashMap<>();
+
+        putGeneralInfo(extrinsicObject, extrinsicObjectMap);
+
+        if (extrinsicObject.isSetContentVersionInfo()) {
+            extrinsicObjectMap.put(EXTRINSIC_OBJECT_CONTENT_VERSION,
+                    extrinsicObject.getContentVersionInfo()
+                            .getVersionName());
+        }
+
+        if (extrinsicObject.isSetIsOpaque()) {
+            extrinsicObjectMap.put(EXTRINSIC_OBJECT_OPAQUE, extrinsicObject.isIsOpaque());
+        }
+
+        if (extrinsicObject.isSetMimeType()) {
+            extrinsicObjectMap.put(EXTRINSIC_OBJECT_MIME_TYPE, extrinsicObject.getMimeType());
+        }
+
+        if (extrinsicObject.isSetExternalIdentifier()) {
+            putExternalIdentifier(extrinsicObject.getExternalIdentifier(), extrinsicObjectMap);
+        }
+
+        if (!extrinsicObjectMap.isEmpty()) {
+            registryObjectListMap.putIfAbsent(EXTRINSIC_OBJECT_KEY,
+                    new ArrayList<Map<String, Object>>());
+            ((List) registryObjectListMap.get(EXTRINSIC_OBJECT_KEY)).add(extrinsicObjectMap);
+        }
+    }
+
+    private static void populateROLWithExtrinsicObject(
+            List<Map<String, Object>> extrinsicObjectsMapList,
+            RegistryObjectListType registryObjectList) {
+        for (Map<String, Object> extrinsicMap : extrinsicObjectsMapList) {
+            ExtrinsicObjectType extrinsicObject = getExtrinsicObjectFromMap(extrinsicMap);
+
+            if (extrinsicObject != null) {
+                registryObjectList.getIdentifiable()
+                        .add(RIM_FACTORY.createExtrinsicObject(extrinsicObject));
+            }
+        }
+    }
+
+    private static void populateROLWithService(List<Map<String, Object>> serviceMapList,
+            RegistryObjectListType registryObjectList) {
+        for (Map<String, Object> serviceMap : serviceMapList) {
+            ServiceType service = getServiceFromMap(serviceMap);
+
+            if (service != null) {
+                registryObjectList.getIdentifiable()
+                        .add(RIM_FACTORY.createService(service));
+            }
+        }
+    }
+
+    private static void populateROLWithOrganization(List<Map<String, Object>> organizationMapList,
+            RegistryObjectListType registryObjectList) {
+        for (Map<String, Object> organizationMap : organizationMapList) {
+            OrganizationType organization = getOrganizationFromMap(organizationMap);
+
+            if (organization != null) {
+                registryObjectList.getIdentifiable()
+                        .add(RIM_FACTORY.createOrganization(organization));
+            }
+        }
+    }
+
+    private static void populateROLWithPerson(List<Map<String, Object>> mapList,
+            RegistryObjectListType registryObjectList) {
+        for (Map<String, Object> personMap : mapList) {
+            PersonType person = getPersonFromMap(personMap);
+
+            if (person != null) {
+                registryObjectList.getIdentifiable()
+                        .add(RIM_FACTORY.createPerson(person));
+            }
+        }
+    }
+
+    private static void populateROLWithAssociation(List<Map<String, Object>> mapList,
+            RegistryObjectListType registryObjectList) {
+        for (Map<String, Object> associationMap : mapList) {
+            AssociationType1 association = getAssociationFromMap(associationMap);
+
+            if (association != null) {
+                registryObjectList.getIdentifiable()
+                        .add(RIM_FACTORY.createAssociation(association));
+            }
+        }
+    }
+
+    private static AssociationType1 getAssociationFromMap(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+
+        AssociationType1 association = RIM_FACTORY.createAssociationType1();
+        boolean populated = populateGeneralInfo(map, association);
+
+        String valueToPopulate = getStringFromMap(ASSOCIATION_TYPE, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            association.setAssociationType(valueToPopulate);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(ASSOCIATION_SOURCE_OBJECT, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            association.setSourceObject(valueToPopulate);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(ASSOCIATION_TARGET_OBJECT, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            association.setTargetObject(valueToPopulate);
+            populated = true;
+        }
+
+        if (!populated) {
+            association = null;
+        }
+
+        return association;
+    }
+
+    private static PersonType getPersonFromMap(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+
+        PersonType person = RIM_FACTORY.createPersonType();
+        populateGeneralInfo(map, person);
+
+        if (map.containsKey(ADDRESS_KEY)) {
+            populateAddressList((List<Map<String, Object>>) map.get(ADDRESS_KEY),
+                    person.getAddress());
+        }
+
+        if (map.containsKey(EMAIL_ADDRESS_KEY)) {
+            populateEmailAddressList((List<Map<String, Object>>) map.get(EMAIL_ADDRESS_KEY),
+                    person.getEmailAddress());
+        }
+
+        if (map.containsKey(PERSON_NAME_KEY)) {
+            person.setPersonName(getPersonNameFromMap((Map<String, Object>) map.get(PERSON_NAME_KEY)));
+        }
+
+        if (map.containsKey(TELEPHONE_KEY)) {
+            populateTelephoneList((List<Map<String, Object>>) map.get(TELEPHONE_KEY),
+                    person.getTelephoneNumber());
+        }
+
+        return person;
+    }
+
+    private static ExtrinsicObjectType getExtrinsicObjectFromMap(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+
+        ExtrinsicObjectType extrinsicObject = RIM_FACTORY.createExtrinsicObjectType();
+        boolean populated = populateGeneralInfo(map, extrinsicObject);
+
+        String valueToPopulate = getStringFromMap(EXTRINSIC_OBJECT_CONTENT_VERSION, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            VersionInfoType contentVersionInfo = RIM_FACTORY.createVersionInfoType();
+            contentVersionInfo.setVersionName(valueToPopulate);
+
+            extrinsicObject.setContentVersionInfo(contentVersionInfo);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(EXTRINSIC_OBJECT_MIME_TYPE, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            extrinsicObject.setMimeType(valueToPopulate);
+            populated = true;
+        }
+
+        Boolean booleanToPopulate = getBooleanFromMap(EXTRINSIC_OBJECT_OPAQUE, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            extrinsicObject.setIsOpaque(booleanToPopulate);
+            populated = true;
+        }
+
+        if (!populated) {
+            extrinsicObject = null;
+        }
+
+        return extrinsicObject;
+    }
+
+    private static ServiceType getServiceFromMap(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+
+        ServiceType service = RIM_FACTORY.createServiceType();
+        boolean populated = populateGeneralInfo(map, service);
+
+        if (map.containsKey(SERVICE_BINDING_KEY)) {
+            populateServiceBindingList((List<Map<String, Object>>) map.get(SERVICE_BINDING_KEY),
+                    service.getServiceBinding());
+            if (!service.getServiceBinding()
+                    .isEmpty()) {
+                populated = true;
+            }
+        }
+
+        if (!populated) {
+            service = null;
+        }
+
+        return service;
+    }
+
+    private static OrganizationType getOrganizationFromMap(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+
+        OrganizationType organization = RIM_FACTORY.createOrganizationType();
+        populateGeneralInfo(map, organization);
+
+        if (map.containsKey(ADDRESS_KEY)) {
+            populateAddressList((List<Map<String, Object>>) map.get(ADDRESS_KEY),
+                    organization.getAddress());
+        }
+
+        if (map.containsKey(EMAIL_ADDRESS_KEY)) {
+            populateEmailAddressList((List<Map<String, Object>>) map.get(EMAIL_ADDRESS_KEY),
+                    organization.getEmailAddress());
+        }
+
+        String valueToPopulate = getStringFromMap(PARENT_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            organization.setParent(valueToPopulate);
+        }
+
+        valueToPopulate = getStringFromMap(PRIMARY_CONTACT, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            organization.setPrimaryContact(valueToPopulate);
+        }
+
+        if (map.containsKey(TELEPHONE_KEY)) {
+            populateTelephoneList((List<Map<String, Object>>) map.get(TELEPHONE_KEY),
+                    organization.getTelephoneNumber());
+        }
+
+        return organization;
+    }
+
+    private static void populateTelephoneList(List<Map<String, Object>> mapList,
+            List<TelephoneNumberType> telephoneNumberList) {
+        for (Map<String, Object> map : mapList) {
+            boolean populated = false;
+
+            TelephoneNumberType telephoneNumber = RIM_FACTORY.createTelephoneNumberType();
+
+            String valueToPopulate = getStringFromMap(PHONE_AREA_CODE, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                telephoneNumber.setAreaCode(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(PHONE_COUNTRY_CODE, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                telephoneNumber.setCountryCode(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(PHONE_EXTENSION, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                telephoneNumber.setExtension(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(PHONE_NUMBER, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                telephoneNumber.setNumber(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(PHONE_TYPE, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                telephoneNumber.setPhoneType(valueToPopulate);
+                populated = true;
+            }
+
+            if (populated) {
+                telephoneNumberList.add(telephoneNumber);
+            }
+        }
+    }
+
+    private static void populateEmailAddressList(List<Map<String, Object>> mapList,
+            List<EmailAddressType> emailAddressList) {
+        for (Map<String, Object> map : mapList) {
+            boolean populated = false;
+            EmailAddressType emailAddress = RIM_FACTORY.createEmailAddressType();
+
+            String valueToPopulate = getStringFromMap(EMAIL_ADDRESS, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                emailAddress.setAddress(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(EMAIL_TYPE, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                emailAddress.setType(valueToPopulate);
+                populated = true;
+            }
+
+            if (populated) {
+                emailAddressList.add(emailAddress);
+            }
+        }
+    }
+
+    private static void populateAddressList(List<Map<String, Object>> mapList,
+            List<PostalAddressType> addressList) {
+        for (Map<String, Object> map : mapList) {
+            boolean populated = false;
+            PostalAddressType address = RIM_FACTORY.createPostalAddressType();
+
+            String valueToPopulate = getStringFromMap(ADDRESS_CITY, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                address.setCity(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(ADDRESS_COUNTRY, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                address.setCountry(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(ADDRESS_POSTAL_CODE, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                address.setPostalCode(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(ADDRESS_STATE_OR_PROVINCE, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                address.setStateOrProvince(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(ADDRESS_STREET, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                address.setStreet(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(ADDRESS_STREET_NUMBER, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                address.setStreetNumber(valueToPopulate);
+                populated = true;
+            }
+
+            if (populated) {
+                addressList.add(address);
+            }
+        }
+    }
+
+    private static void populateServiceBindingList(List<Map<String, Object>> mapList,
+            List<ServiceBindingType> serviceBindings) {
+        for (Map<String, Object> map : mapList) {
+            ServiceBindingType serviceBinding = RIM_FACTORY.createServiceBindingType();
+
+            boolean populated = populateGeneralInfo(map, serviceBinding);
+
+            String valueToPopulate = getStringFromMap(BINDING_ACCESS_URI, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                serviceBinding.setAccessURI(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(BINDING_SERVICE, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                serviceBinding.setService(valueToPopulate);
+                populated = true;
+            }
+
+            if (map.containsKey(SPECIFICATION_LINK_KEY)) {
+                populateSpecificationLinkList((List<Map<String, Object>>) map.get(
+                        SPECIFICATION_LINK_KEY), serviceBinding.getSpecificationLink());
+                if (!serviceBinding.getSpecificationLink()
+                        .isEmpty()) {
+                    populated = true;
+                }
+            }
+
+            valueToPopulate = getStringFromMap(BINDING_TARGET_BINDING, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                serviceBinding.setTargetBinding(valueToPopulate);
+                populated = true;
+            }
+
+            if (populated) {
+                serviceBindings.add(serviceBinding);
+            }
+        }
+    }
+
+    private static void populateSpecificationLinkList(List<Map<String, Object>> mapList,
+            List<SpecificationLinkType> specificationLinkList) {
+        for (Map<String, Object> map : mapList) {
+            boolean populated = false;
+            SpecificationLinkType specificationLink = RIM_FACTORY.createSpecificationLinkType();
+            populateGeneralInfo(map, specificationLink);
+
+            String valueToPopulate = getStringFromMap(SPECIFICATION_LINK_SERVICE_BINDING, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                specificationLink.setServiceBinding(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(SPECIFICATION_LINK_SPECIFICATION_OBJECT, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                specificationLink.setSpecificationObject(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(SPECIFICATION_LINK_USAGE_DESCRIPTION, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                InternationalStringType istToPopulate = getISTFromString(valueToPopulate);
+                if (istToPopulate != null) {
+                    specificationLink.setUsageDescription(istToPopulate);
+                    populated = true;
+                }
+            }
+
+            if (map.containsKey(SPECIFICATION_LINK_USAGE_PARAMETERS)) {
+                specificationLink.getUsageParameter()
+                        .addAll(getStringListFromMap(map, SPECIFICATION_LINK_USAGE_PARAMETERS));
+            }
+
+            if (populated) {
+                specificationLinkList.add(specificationLink);
+            }
+        }
+    }
+
+    private static void populateExternalIdentifierList(List<Map<String, Object>> mapList,
+            List<ExternalIdentifierType> externalIdentifierList) {
+        if (mapList == null) {
+            return;
+        }
+
+        for (Map<String, Object> extIdMap : mapList) {
+            boolean populated = false;
+            ExternalIdentifierType extId = RIM_FACTORY.createExternalIdentifierType();
+            populateGeneralInfo(extIdMap, extId);
+
+            String valueToPopulate = getStringFromMap(EXT_ID_IDENTIFICATION_SCHEME, extIdMap);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                extId.setIdentificationScheme(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(EXT_ID_REGISTRY_OBJECT, extIdMap);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                extId.setRegistryObject(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(EXT_ID_VALUE, extIdMap);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                extId.setValue(valueToPopulate);
+                populated = true;
+            }
+
+            if (populated) {
+                externalIdentifierList.add(extId);
+            }
+        }
+    }
+
+    private static void populateClassificationList(List<Map<String, Object>> mapList,
+            List<ClassificationType> classificationList) {
+        if (mapList == null) {
+            return;
+        }
+
+        for (Map<String, Object> map : mapList) {
+            boolean populated = false;
+            ClassificationType classification = RIM_FACTORY.createClassificationType();
+            populateGeneralInfo(map, classification);
+
+            String valueToPopulate = getStringFromMap(CLASSIFICATION_NODE, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                classification.setClassificationNode(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(CLASSIFICATION_SCHEME, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                classification.setClassificationScheme(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(CLASSIFIED_OBJECT, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                classification.setClassifiedObject(valueToPopulate);
+                populated = true;
+            }
+
+            valueToPopulate = getStringFromMap(NODE_REPRESENTATION, map);
+            if (StringUtils.isNotBlank(valueToPopulate)) {
+                classification.setNodeRepresentation(valueToPopulate);
+                populated = true;
+            }
+
+            if (populated) {
+                classificationList.add(classification);
+            }
+        }
+    }
+
+    private static void putRegistryAssociation(AssociationType1 association,
+            Map<String, Object> registryObjectListMap) {
+        if (association == null) {
+            return;
+        }
+        Map<String, Object> associationMap = new HashMap<>();
+
+        putGeneralInfo(association, associationMap);
+
+        if (association.isSetAssociationType()) {
+            associationMap.put(ASSOCIATION_TYPE, association.getAssociationType());
+        }
+
+        if (association.isSetSourceObject()) {
+            associationMap.put(ASSOCIATION_SOURCE_OBJECT, association.getSourceObject());
+        }
+
+        if (association.isSetTargetObject()) {
+            associationMap.put(ASSOCIATION_TARGET_OBJECT, association.getTargetObject());
+        }
+
+        if (!associationMap.isEmpty()) {
+            registryObjectListMap.putIfAbsent(ASSOCIATION_KEY,
+                    new ArrayList<Map<String, Object>>());
+            ((List) registryObjectListMap.get(ASSOCIATION_KEY)).add(associationMap);
+        }
+    }
+
+    private static void putRegistryService(ServiceType service,
+            Map<String, Object> registryObjectListMap) {
+        if (service == null) {
+            return;
+        }
+        Map<String, Object> serviceMap = new HashMap<>();
+
+        putGeneralInfo(service, serviceMap);
+
+        if (service.isSetServiceBinding()) {
+            putServiceBindings(service.getServiceBinding(), serviceMap);
+        }
+
+        if (!serviceMap.isEmpty()) {
+            registryObjectListMap.putIfAbsent(SERVICE_KEY, new ArrayList<Map<String, Object>>());
+            ((List) registryObjectListMap.get(SERVICE_KEY)).add(serviceMap);
+        }
+
+    }
+
+    private static void putServiceBindings(List<ServiceBindingType> serviceBindings,
+            Map<String, Object> serviceMap) {
+        List<Map<String, Object>> webServiceBindings = new ArrayList<>();
+
+        for (ServiceBindingType binding : serviceBindings) {
+            Map<String, Object> bindingMap = new HashMap<>();
+
+            putGeneralInfo(binding, bindingMap);
+
+            if (binding.isSetAccessURI()) {
+                bindingMap.put(BINDING_ACCESS_URI, binding.getAccessURI());
+            }
+
+            if (binding.isSetService()) {
+                bindingMap.put(BINDING_SERVICE, binding.getService());
+            }
+
+            if (binding.isSetSpecificationLink()) {
+                putSpecificationLinks(binding.getSpecificationLink(), bindingMap);
+            }
+
+            if (binding.isSetTargetBinding()) {
+                bindingMap.put(BINDING_TARGET_BINDING, binding.getTargetBinding());
+            }
+
+            webServiceBindings.add(bindingMap);
+        }
+
+        if (CollectionUtils.isNotEmpty(webServiceBindings)) {
+            serviceMap.put(SERVICE_BINDING_KEY, webServiceBindings);
+        }
+    }
+
+    private static void putSpecificationLinks(List<SpecificationLinkType> specificationLinks,
+            Map<String, Object> serviceBindingMap) {
+        List<Map<String, Object>> webSpecificationLinks = new ArrayList<>();
+
+        for (SpecificationLinkType specificationLink : specificationLinks) {
+            Map<String, Object> specificationLinkMap = new HashMap<>();
+
+            putGeneralInfo(specificationLink, specificationLinkMap);
+
+            if (specificationLink.isSetServiceBinding()) {
+                specificationLinkMap.put(SPECIFICATION_LINK_SERVICE_BINDING,
+                        specificationLink.getServiceBinding());
+            }
+
+            if (specificationLink.isSetSpecificationObject()) {
+                specificationLinkMap.put(SPECIFICATION_LINK_SPECIFICATION_OBJECT,
+                        specificationLink.getSpecificationObject());
+
+            }
+
+            if (specificationLink.isSetUsageDescription()) {
+                specificationLinkMap.put(SPECIFICATION_LINK_USAGE_DESCRIPTION,
+                        getStringFromIST(specificationLink.getUsageDescription()));
+            }
+
+            if (specificationLink.isSetUsageParameter()) {
+                specificationLinkMap.put(SPECIFICATION_LINK_USAGE_PARAMETERS,
+                        specificationLink.getUsageParameter());
+            }
+
+            if (!specificationLinkMap.isEmpty()) {
+                webSpecificationLinks.add(specificationLinkMap);
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(webSpecificationLinks)) {
+            serviceBindingMap.put(SPECIFICATION_LINK_KEY, webSpecificationLinks);
+        }
+    }
+
+    private static void putRegistryOrganization(OrganizationType organization,
+            Map<String, Object> registryObjectListMap) {
+        if (organization == null) {
+            return;
+        }
+        Map<String, Object> organizationMap = new HashMap<>();
+
+        putGeneralInfo(organization, organizationMap);
+
+        if (organization.isSetAddress()) {
+            putAddress(organization.getAddress(), organizationMap);
+        }
+
+        if (organization.isSetEmailAddress()) {
+            putEmailAddress(organization.getEmailAddress(), organizationMap);
+        }
+
+        if (organization.isSetParent()) {
+            organizationMap.put(PARENT_KEY, organization.getParent());
+        }
+
+        if (organization.isSetPrimaryContact()) {
+            organizationMap.put(PRIMARY_CONTACT, organization.getPrimaryContact());
+        }
+
+        if (organization.isSetTelephoneNumber()) {
+            putTelephoneNumber(organization.getTelephoneNumber(), organizationMap);
+        }
+
+        if (!organizationMap.isEmpty()) {
+            registryObjectListMap.putIfAbsent(ORGANIZATION_KEY,
+                    new ArrayList<Map<String, Object>>());
+            ((List) registryObjectListMap.get(ORGANIZATION_KEY)).add(organizationMap);
+        }
+    }
+
+    private static void putRegistryPerson(PersonType person,
+            Map<String, Object> registryObjectListMap) {
+        if (person == null) {
+            return;
+        }
+
+        Map<String, Object> personMap = new HashMap<>();
+
+        putGeneralInfo(person, personMap);
+
+        if (person.isSetAddress()) {
+            putAddress(person.getAddress(), personMap);
+        }
+
+        if (person.isSetEmailAddress()) {
+            putEmailAddress(person.getEmailAddress(), personMap);
+        }
+
+        if (person.isSetPersonName()) {
+            putPersonName(person.getPersonName(), personMap);
+        }
+
+        if (person.isSetTelephoneNumber()) {
+            putTelephoneNumber(person.getTelephoneNumber(), personMap);
+        }
+
+        if (!personMap.isEmpty()) {
+            registryObjectListMap.putIfAbsent(PERSON_KEY, new ArrayList<Map<String, Object>>());
+            ((List) registryObjectListMap.get(PERSON_KEY)).add(personMap);
+        }
+    }
+
+    private static void putExternalIdentifier(List<ExternalIdentifierType> extIds,
+            Map<String, Object> map) {
+        List<Map<String, Object>> webExternalIds = new ArrayList<>();
+
+        for (ExternalIdentifierType extId : extIds) {
+            Map<String, Object> externalIdMap = new HashMap<>();
+
+            putGeneralInfo(extId, externalIdMap);
+
+            if (extId.isSetIdentificationScheme()) {
+                externalIdMap.put(EXT_ID_IDENTIFICATION_SCHEME, extId.getIdentificationScheme());
+            }
+
+            if (extId.isSetRegistryObject()) {
+                externalIdMap.put(EXT_ID_REGISTRY_OBJECT, extId.getRegistryObject());
+            }
+
+            if (extId.isSetValue()) {
+                externalIdMap.put(EXT_ID_VALUE, extId.getValue());
+            }
+
+            if (!externalIdMap.isEmpty()) {
+                webExternalIds.add(externalIdMap);
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(webExternalIds)) {
+            map.put(EXTERNAL_IDENTIFIER_KEY, webExternalIds);
+        }
+    }
+
+    private static void putPersonName(PersonNameType personName, Map<String, Object> personMap) {
+        Map<String, Object> personNameParts = new HashMap<>();
+
+        if (personName.isSetFirstName()) {
+            personNameParts.put(PERSON_FIRST_NAME, personName.getFirstName());
+        }
+
+        if (personName.isSetMiddleName()) {
+            personNameParts.put(PERSON_MIDDLE_NAME, personName.getMiddleName());
+        }
+
+        if (personName.isSetLastName()) {
+            personNameParts.put(PERSON_LAST_NAME, personName.getLastName());
+        }
+
+        if (!personNameParts.isEmpty()) {
+            personMap.put(PERSON_NAME_KEY, personNameParts);
+        }
+    }
+
+    private static PersonNameType getPersonNameFromMap(Map<String, Object> map) {
+        if (map == null) {
+            return null;
+        }
+
+        boolean populated = false;
+        PersonNameType personName = RIM_FACTORY.createPersonNameType();
+
+        String valueToPopulate = getStringFromMap(PERSON_FIRST_NAME, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            personName.setFirstName(valueToPopulate);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(PERSON_LAST_NAME, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            personName.setLastName(valueToPopulate);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(PERSON_MIDDLE_NAME, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            personName.setMiddleName(valueToPopulate);
+            populated = true;
+        }
+
+        if (!populated) {
+            personName = null;
+        }
+
+        return personName;
+    }
+
+    private static void putEmailAddress(List<EmailAddressType> emailAddresses,
+            Map<String, Object> organizationMap) {
+        List<Map<String, Object>> webEmailAddresses = new ArrayList<>();
+
+        for (EmailAddressType emailAddress : emailAddresses) {
+            Map<String, Object> emailAddressMap = new HashMap<>();
+
+            if (emailAddress.isSetAddress()) {
+                emailAddressMap.put(EMAIL_ADDRESS, emailAddress.getAddress());
+            }
+
+            if (emailAddress.isSetType()) {
+                emailAddressMap.put(EMAIL_TYPE, emailAddress.getType());
+            }
+
+            if (!emailAddressMap.isEmpty()) {
+                webEmailAddresses.add(emailAddressMap);
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(webEmailAddresses)) {
+            organizationMap.put(EMAIL_ADDRESS_KEY, webEmailAddresses);
+        }
+    }
+
+    private static void putTelephoneNumber(List<TelephoneNumberType> phoneNumbers,
+            Map<String, Object> organizationMap) {
+        List<Map<String, Object>> webPhoneNumbers = new ArrayList<>();
+
+        for (TelephoneNumberType phoneNumber : phoneNumbers) {
+            Map<String, Object> phoneNumberMap = new HashMap<>();
+
+            if (phoneNumber.isSetAreaCode()) {
+                phoneNumberMap.put(PHONE_AREA_CODE, phoneNumber.getAreaCode());
+            }
+
+            if (phoneNumber.isSetCountryCode()) {
+                phoneNumberMap.put(PHONE_COUNTRY_CODE, phoneNumber.getCountryCode());
+            }
+
+            if (phoneNumber.isSetExtension()) {
+                phoneNumberMap.put(PHONE_EXTENSION, phoneNumber.getExtension());
+            }
+
+            if (phoneNumber.isSetNumber()) {
+                phoneNumberMap.put(PHONE_NUMBER, phoneNumber.getNumber());
+            }
+
+            if (phoneNumber.isSetPhoneType()) {
+                phoneNumberMap.putIfAbsent(PHONE_TYPE, phoneNumber.getPhoneType());
+            }
+
+            if (!phoneNumberMap.isEmpty()) {
+                webPhoneNumbers.add(phoneNumberMap);
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(webPhoneNumbers)) {
+            organizationMap.put(TELEPHONE_KEY, webPhoneNumbers);
+        }
+    }
+
+    private static void putAddress(List<PostalAddressType> addresses,
+            Map<String, Object> organizationMap) {
+        List<Map<String, Object>> webAddresses = new ArrayList<>();
+
+        for (PostalAddressType postalAddress : addresses) {
+            Map<String, Object> addressMap = new HashMap<>();
+
+            if (postalAddress.isSetCity()) {
+                addressMap.put(ADDRESS_CITY, postalAddress.getCity());
+            }
+
+            if (postalAddress.isSetCountry()) {
+                addressMap.put(ADDRESS_COUNTRY, postalAddress.getCountry());
+            }
+
+            if (postalAddress.isSetPostalCode()) {
+                addressMap.put(ADDRESS_POSTAL_CODE, postalAddress.getPostalCode());
+            }
+
+            if (postalAddress.isSetStateOrProvince()) {
+                addressMap.put(ADDRESS_STATE_OR_PROVINCE, postalAddress.getStateOrProvince());
+            }
+
+            if (postalAddress.isSetStreet()) {
+                addressMap.put(ADDRESS_STREET, postalAddress.getStreet());
+            }
+
+            if (postalAddress.isSetStreetNumber()) {
+                addressMap.put(ADDRESS_STREET_NUMBER, postalAddress.getStreet());
+            }
+
+            if (!addressMap.isEmpty()) {
+                webAddresses.add(addressMap);
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(webAddresses)) {
+            organizationMap.put(ADDRESS_KEY, webAddresses);
+        }
+    }
+
+    private static void putClassification(List<ClassificationType> classifications,
+            Map<String, Object> map) {
+        List<Map<String, Object>> webClassifications = new ArrayList<>();
+
+        for (ClassificationType classification : classifications) {
+            Map<String, Object> classificationMap = new HashMap<>();
+
+            putGeneralInfo(classification, classificationMap);
+
+            if (classification.isSetClassificationNode()) {
+                classificationMap.put(CLASSIFICATION_NODE, classification.getClassificationNode());
+            }
+
+            if (classification.isSetClassificationScheme()) {
+                classificationMap.put(CLASSIFICATION_SCHEME,
+                        classification.getClassificationScheme());
+            }
+
+            if (classification.isSetClassifiedObject()) {
+                classificationMap.put(CLASSIFIED_OBJECT, classification.getClassifiedObject());
+            }
+
+            if (classification.isSetNodeRepresentation()) {
+                classificationMap.put(NODE_REPRESENTATION, classification.getNodeRepresentation());
+            }
+
+            if (!classificationMap.isEmpty()) {
+                webClassifications.add(classificationMap);
+            }
+        }
+
+        if (CollectionUtils.isNotEmpty(webClassifications)) {
+            map.put(CLASSIFICATION_KEY, webClassifications);
+        }
+    }
+
+    private static void putGeneralInfo(RegistryObjectType registryObject, Map<String, Object> map) {
+        if (registryObject.isSetClassification()) {
+            putClassification(registryObject.getClassification(), map);
+        }
+
+        if (registryObject.isSetDescription()) {
+            putStringValue(DESCRIPTION_KEY, getStringFromIST(registryObject.getDescription()), map);
+        }
+
+        if (registryObject.isSetExternalIdentifier()) {
+            putExternalIdentifier(registryObject.getExternalIdentifier(), map);
+        }
+
+        if (registryObject.isSetHome()) {
+            putStringValue(HOME_KEY, registryObject.getHome(), map);
+        }
+
+        if (registryObject.isSetId()) {
+            putStringValue(ID_KEY, registryObject.getId(), map);
+        }
+
+        if (registryObject.isSetLid()) {
+            putStringValue(LID_KEY, registryObject.getLid(), map);
+        }
+
+        if (registryObject.isSetName()) {
+            putStringValue(NAME_KEY, getStringFromIST(registryObject.getName()), map);
+        }
+
+        if (registryObject.isSetObjectType()) {
+            putStringValue(OBJECT_TYPE_KEY, registryObject.getObjectType(), map);
+        }
+
+        if (registryObject.isSetSlot()) {
+            putSlotList(registryObject.getSlot(), map);
+        }
+
+        if (registryObject.isSetStatus()) {
+            putStringValue(STATUS_KEY, registryObject.getStatus(), map);
+        }
+
+        if (registryObject.isSetVersionInfo()) {
+            String versionName = registryObject.getVersionInfo()
+                    .getVersionName();
+            putStringValue(VERSION_INFO_KEY, versionName, map);
+
+        }
+
+    }
+
+    private static boolean populateGeneralInfo(Map<String, Object> map,
+            RegistryObjectType registryObject) {
+        boolean populated = false;
+        if (map.containsKey(CLASSIFICATION_KEY)) {
+            populateClassificationList((List<Map<String, Object>>) map.get(CLASSIFICATION_KEY),
+                    registryObject.getClassification());
+            if (!registryObject.getClassification()
+                    .isEmpty()) {
+                populated = true;
+            }
+        }
+
+        String valueToPopulate = getStringFromMap(DESCRIPTION_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            InternationalStringType istToPopulate = getISTFromString(valueToPopulate);
+            if (istToPopulate != null) {
+                registryObject.setDescription(istToPopulate);
+                populated = true;
+            }
+        }
+
+        if (map.containsKey(EXTERNAL_IDENTIFIER_KEY)) {
+            populateExternalIdentifierList((List<Map<String, Object>>) map.get(
+                    EXTERNAL_IDENTIFIER_KEY), registryObject.getExternalIdentifier());
+            if (!registryObject.getExternalIdentifier()
+                    .isEmpty()) {
+                populated = true;
+            }
+        }
+
+        valueToPopulate = getStringFromMap(HOME_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            registryObject.setHome(valueToPopulate);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(ID_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            registryObject.setId(valueToPopulate);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(LID_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            registryObject.setLid(valueToPopulate);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(NAME_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            InternationalStringType istToPopulate = getISTFromString(valueToPopulate);
+            if (istToPopulate != null) {
+                registryObject.setName(istToPopulate);
+                populated = true;
+            }
+        }
+
+        valueToPopulate = getStringFromMap(OBJECT_TYPE_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            registryObject.setObjectType(valueToPopulate);
+            populated = true;
+        }
+
+        if (map.containsKey(SLOT)) {
+            populateSlotList((List<Map<String, Object>>) map.get(SLOT), registryObject.getSlot());
+            if (!registryObject.getSlot()
+                    .isEmpty()) {
+                populated = true;
+            }
+        }
+
+        valueToPopulate = getStringFromMap(STATUS_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            registryObject.setStatus(valueToPopulate);
+            populated = true;
+        }
+
+        valueToPopulate = getStringFromMap(VERSION_INFO_KEY, map);
+        if (StringUtils.isNotBlank(valueToPopulate)) {
+            VersionInfoType versionInfo = RIM_FACTORY.createVersionInfoType();
+            versionInfo.setVersionName(valueToPopulate);
+
+            registryObject.setVersionInfo(versionInfo);
+            populated = true;
+        }
+
+        return populated;
+    }
+
+    private static String getStringFromMap(String key, Map<String, Object> map) {
+        String value = null;
+        if (map.containsKey(key)) {
+            value = (String) map.get(key);
+        }
+
+        return value;
+    }
+
+    private static BigInteger getBigIntFromMap(String key, Map<String, Object> map) {
+        BigInteger value = null;
+        if (map.containsKey(key)) {
+            // Using String.valueOf so that it can handle Integer and Long the same
+            value = new BigInteger(String.valueOf(map.get(key)));
+        }
+
+        return value;
+    }
+
+    private static Boolean getBooleanFromMap(String key, Map<String, Object> map) {
+        Boolean value = null;
+        if (map.containsKey(key)) {
+            value = (Boolean) map.get(key);
+        }
+
+        return value;
+    }
+
+    private static void putSlotList(List<SlotType1> slots, Map<String, Object> map) {
+
+        List<Map<String, Object>> slotList = new ArrayList<>();
+
+        for (SlotType1 slot : slots) {
+            addSlotMapToList(slot, slotList);
+        }
+
+        if (CollectionUtils.isNotEmpty(slotList)) {
+            map.put(SLOT, slotList);
+        }
+    }
+
+    private static void populateSlotList(List<Map<String, Object>> mapList, List<SlotType1> slots) {
+        for (Map<String, Object> map : mapList) {
+            boolean populated = false;
+
+            SlotType1 slot = RIM_FACTORY.createSlotType1();
+
+            String slotType = getStringFromMap(SLOT_TYPE, map);
+            if (StringUtils.isNotBlank(slotType)) {
+                if (slotType.contains(XML_GEO_TYPE)) {
+                    populateSlotGMPointValue(map, slot);
+                } else {
+                    populateSlotStringValue(map, slot);
+                }
+
+                slot.setSlotType(slotType);
+                populated = true;
+            } else {
+                populateSlotStringValue(map, slot);
+                if (!slot.getValueList()
+                        .getValue()
+                        .getValue()
+                        .isEmpty()) {
+                    populated = true;
+                }
+            }
+
+            String name = getStringFromMap(NAME, map);
+            if (StringUtils.isNotBlank(name)) {
+                slot.setName(name);
+                populated = true;
+            }
+
+            if (populated) {
+                slots.add(slot);
+            }
+        }
+    }
+
+    private static void populateSlotStringValue(Map<String, Object> map, SlotType1 slot) {
+        ValueListType valueList = RIM_FACTORY.createValueListType();
+        valueList.getValue()
+                .addAll(getStringListFromMap(map, VALUE));
+
+        slot.setValueList(RIM_FACTORY.createValueList(valueList));
+    }
+
+    private static boolean populateSlotGMPointValue(Map<String, Object> map, SlotType1 slot) {
+        boolean populated = false;
+        PointType point = GML_FACTORY.createPointType();
+
+        if (map.containsKey(VALUE)) {
+            Map<String, Object> valueMap = (Map<String, Object>) map.get(VALUE);
+
+            if (valueMap.containsKey(POINT_KEY)) {
+                Map<String, Object> pointMap = (Map<String, Object>) valueMap.get(POINT_KEY);
+
+                BigInteger dimension = getBigIntFromMap(SRS_DIMENSION, pointMap);
+                if (dimension != null) {
+                    point.setSrsDimension(dimension);
+                    populated = true;
+                }
+
+                String valueToPopulate = getStringFromMap(SRS_NAME, pointMap);
+                if (StringUtils.isNotBlank(valueToPopulate)) {
+                    point.setSrsName(valueToPopulate);
+                    populated = true;
+                }
+
+                valueToPopulate = getStringFromMap(POSITION, pointMap);
+                if (StringUtils.isNotBlank(valueToPopulate)) {
+                    String[] values = StringUtils.split(valueToPopulate);
+
+                    DirectPositionType directPosition = GML_FACTORY.createDirectPositionType();
+
+                    for (String value : values) {
+                        directPosition.getValue()
+                                .add(Double.valueOf(value));
+                    }
+
+                    point.setPos(directPosition);
+                    populated = true;
+                }
+
+                if (populated) {
+                    AnyValueType anyValue = WRS_FACTORY.createAnyValueType();
+                    anyValue.getContent()
+                            .add(GML_FACTORY.createPoint(point));
+
+                    net.opengis.cat.wrs.v_1_0_2.ValueListType valueList =
+                            WRS_FACTORY.createValueListType();
+                    valueList.getAnyValue()
+                            .add(anyValue);
+
+                    slot.setValueList(RIM_FACTORY.createValueList(valueList));
+                }
+            }
+
+        }
+
+        return populated;
+    }
+
+    private static List<String> getStringListFromMap(Map<String, Object> map, String key) {
+        if (!map.containsKey(key)) {
+            return null;
+        }
+
+        return (List<String>) map.get(key);
+    }
+
+    private static void addSlotMapToList(SlotType1 slot, List<Map<String, Object>> slotList) {
+        if (slot.isSetSlotType()) {
+            String slotType = slot.getSlotType();
+
+            if (slotType.contains(XML_DATE_TIME_TYPE)) {
+                putSlotDateValue(slot, slotList);
+            } else if (slotType.contains(XML_GEO_TYPE)) {
+                putSlotGeoValue(slot, slotList);
+            } else {
+                putSlotStringValue(slot, slotList);
+            }
+        } else {
+            putSlotStringValue(slot, slotList);
+        }
+
+    }
+
+    private static void putSlotDateValue(SlotType1 slot, List<Map<String, Object>> list) {
+        List<Date> dates = getSlotDateValues(slot);
+
+        if (CollectionUtils.isNotEmpty(dates)) {
+            Map<String, Object> map = new HashMap<>();
+            map.put(NAME, slot.getName());
+            map.put(VALUE, dates);
+            if (slot.isSetSlotType()) {
+                map.put(SLOT_TYPE, slot.getSlotType());
+            }
+
+            list.add(map);
+        }
+    }
+
+    private static List<Date> getSlotDateValues(SlotType1 slot) {
+        List<Date> dates = new ArrayList<>();
+
+        if (slot.isSetValueList()) {
+            ValueListType valueList = slot.getValueList()
+                    .getValue();
+
+            if (valueList.isSetValue()) {
+                List<String> values = valueList.getValue();
+
+                for (String dateString : values) {
+                    Date date = dateOptionalTimeParser().parseDateTime(dateString)
+                            .toDate();
+                    if (date != null) {
+                        dates.add(date);
+                    }
+                }
+            }
+        }
+
+        return dates;
+    }
+
+    private static List<String> getSlotStringValues(SlotType1 slot) {
+        List<String> slotValues = new ArrayList<>();
+
+        if (slot.isSetValueList()) {
+            ValueListType valueList = slot.getValueList()
+                    .getValue();
+            if (valueList.isSetValue()) {
+                slotValues = valueList.getValue();
+            }
+        }
+
+        return slotValues;
+    }
+
+    private static void putSlotStringValue(SlotType1 slot, List<Map<String, Object>> list) {
+        List<String> stringValues = getSlotStringValues(slot);
+
+        if (CollectionUtils.isNotEmpty(stringValues)) {
+            Map<String, Object> map = new HashMap<>();
+            map.put(NAME, slot.getName());
+            map.put(VALUE, stringValues);
+            if (slot.isSetSlotType()) {
+                map.put(SLOT_TYPE, slot.getSlotType());
+            }
+
+            list.add(map);
+        }
+    }
+
+    private static void putSlotGeoValue(SlotType1 slot, List<Map<String, Object>> list) {
+        if (slot.isSetValueList()) {
+            net.opengis.cat.wrs.v_1_0_2.ValueListType valueList =
+                    (net.opengis.cat.wrs.v_1_0_2.ValueListType) slot.getValueList()
+                            .getValue();
+
+            List<AnyValueType> anyValues = valueList.getAnyValue();
+
+            for (AnyValueType anyValue : anyValues) {
+                anyValue.getContent()
+                        .stream()
+                        .filter(content -> content instanceof JAXBElement)
+                        .forEach(content -> {
+
+                            JAXBElement jaxbElement = (JAXBElement) content;
+
+                            if (jaxbElement.getValue() instanceof PointType) {
+
+                                Map<String, Object> pointMap =
+                                        getPointMapFromPointType((PointType) jaxbElement.getValue(),
+                                                slot);
+
+                                if (!pointMap.isEmpty()) {
+                                    list.add(pointMap);
+                                }
+                            }
+
+                        });
+            }
+
+        }
+    }
+
+    private static Map<String, Object> getPointMapFromPointType(PointType point, SlotType1 slot) {
+        Map<String, Map<String, Object>> pointMap = new HashMap<>();
+        Map<String, Object> map = new HashMap<>();
+        pointMap.put(POINT_KEY, new HashMap<>());
+        pointMap.get(POINT_KEY)
+                .put(SRS_DIMENSION,
+                        point.getSrsDimension()
+                                .intValue());
+        pointMap.get(POINT_KEY)
+                .put(SRS_NAME, point.getSrsName());
+
+        DirectPositionType directPosition = point.getPos();
+        List<String> pointValues = new ArrayList<>();
+
+        pointValues.addAll(directPosition.getValue()
+                .stream()
+                .map(String::valueOf)
+                .collect(Collectors.toList()));
+
+        String position = String.join(" ", pointValues);
+
+        if (StringUtils.isNotBlank(position)) {
+            pointMap.get(POINT_KEY)
+                    .put(POSITION, position);
+        }
+
+        if (!pointMap.isEmpty()) {
+            map.put(NAME, slot.getName());
+            map.put(VALUE, pointMap);
+            if (slot.isSetSlotType()) {
+                map.put(SLOT_TYPE, slot.getSlotType());
+            }
+        }
+        return map;
+    }
+
+    private static void putStringValue(String key, String value, Map<String, Object> map) {
+        if (StringUtils.isNotBlank(value)) {
+            map.put(key, value);
+        }
+    }
+
+    private static String getStringFromIST(InternationalStringType internationalString) {
+        String stringValue = "";
+        List<LocalizedStringType> localizedStrings = internationalString.getLocalizedString();
+        if (CollectionUtils.isNotEmpty(localizedStrings)) {
+            LocalizedStringType localizedString = localizedStrings.get(0);
+            if (localizedString != null) {
+                stringValue = localizedString.getValue();
+            }
+        }
+
+        return stringValue;
+    }
+
+    private static InternationalStringType getISTFromString(String internationalizeThis) {
+        if (StringUtils.isBlank(internationalizeThis)) {
+            return null;
+        }
+
+        InternationalStringType ist = new InternationalStringType();
+        LocalizedStringType lst = new LocalizedStringType();
+
+        lst.setValue(internationalizeThis);
+        ist.setLocalizedString(Collections.singletonList(lst));
+
+        return ist;
+    }
+
+    private static boolean isRegistryPackageEmpty(RegistryPackageType registryPackage) {
+        if (registryPackage.isSetClassification()) {
+            return false;
+        }
+
+        if (registryPackage.isSetId()) {
+            return false;
+        }
+
+        if (registryPackage.isSetObjectType()) {
+            return false;
+        }
+
+        if (registryPackage.isSetRegistryObjectList()) {
+            return false;
+        }
+
+        if (registryPackage.isSetDescription()) {
+            return false;
+        }
+
+        if (registryPackage.isSetExternalIdentifier()) {
+            return false;
+        }
+
+        if (registryPackage.isSetHome()) {
+            return false;
+        }
+
+        if (registryPackage.isSetLid()) {
+            return false;
+        }
+
+        if (registryPackage.isSetName()) {
+            return false;
+        }
+
+        if (registryPackage.isSetSlot()) {
+            return false;
+        }
+
+        if (registryPackage.isSetStatus()) {
+            return false;
+        }
+
+        if (registryPackage.isSetVersionInfo()) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/catalog/registry/catalog-registry-federationadminimpl/src/main/java/ddf/catalog/registry/federationadmin/impl/FederationAdmin.java
+++ b/catalog/registry/catalog-registry-federationadminimpl/src/main/java/ddf/catalog/registry/federationadmin/impl/FederationAdmin.java
@@ -1,0 +1,340 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.registry.federationadmin.impl;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.StandardMBean;
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.Marshaller;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.configuration.SystemBaseUrl;
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.ParserConfigurator;
+import org.codice.ddf.parser.ParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.registry.common.RegistryConstants;
+import ddf.catalog.registry.common.metacard.RegistryObjectMetacardType;
+import ddf.catalog.registry.federationadmin.FederationAdminMBean;
+import ddf.catalog.registry.federationadmin.converter.RegistryPackageWebConverter;
+import ddf.catalog.registry.federationadmin.service.FederationAdminException;
+import ddf.catalog.registry.federationadmin.service.FederationAdminService;
+import ddf.catalog.transform.CatalogTransformerException;
+import ddf.catalog.transform.InputTransformer;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ObjectFactory;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+
+public class FederationAdmin implements FederationAdminMBean {
+
+    private MBeanServer mbeanServer;
+
+    private ObjectName objectName;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FederationAdmin.class);
+
+    private static final ObjectFactory RIM_FACTORY = new ObjectFactory();
+
+    private FederationAdminService federationAdminService;
+
+    private InputTransformer registryTransformer;
+
+    private Parser parser;
+
+    private ParserConfigurator marshalConfigurator;
+
+    public FederationAdmin() {
+        configureMBean();
+    }
+
+    @Override
+    public String createLocalEntry(Map<String, Object> registryMap)
+            throws FederationAdminException {
+        if (MapUtils.isEmpty(registryMap)) {
+            throw new FederationAdminException(
+                    "Error creating local registry entry. Null map provided.");
+        }
+
+        RegistryPackageType registryPackage =
+                RegistryPackageWebConverter.getRegistryPackageFromWebMap(registryMap);
+
+        if (registryPackage == null) {
+            throw new FederationAdminException(
+                    "Error creating local registry entry. Couldn't convert registry map to a registry package.");
+        }
+
+        if (!registryPackage.isSetHome()) {
+            String home = SystemBaseUrl.getBaseUrl();
+            if (StringUtils.isNotBlank(home)) {
+                registryPackage.setHome(home);
+            }
+        }
+
+        if (!registryPackage.isSetObjectType()) {
+            registryPackage.setObjectType(RegistryConstants.REGISTRY_NODE_OBJECT_TYPE);
+        }
+
+        if (!registryPackage.isSetId()) {
+            String registryPackageId = UUID.randomUUID()
+                    .toString()
+                    .replaceAll("-", "");
+            registryPackage.setId(registryPackageId);
+        }
+
+        Metacard metacard = getRegistryMetacardFromRegistryPackage(registryPackage);
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE,
+                true));
+        return federationAdminService.addRegistryEntry(metacard);
+    }
+
+    @Override
+    public String createLocalEntry(String base64EncodedXmlData) throws FederationAdminException {
+        if (StringUtils.isBlank(base64EncodedXmlData)) {
+            throw new FederationAdminException(
+                    "Error creating local entry. String provided was blank.");
+        }
+
+        String metacardId;
+        try (InputStream xmlStream = new ByteArrayInputStream(Base64.getDecoder()
+                .decode(base64EncodedXmlData))) {
+            Metacard metacard = getRegistryMetacardFromInputStream(xmlStream);
+            metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE,
+                    true));
+            metacardId = federationAdminService.addRegistryEntry(metacard);
+        } catch (IOException | IllegalArgumentException e) {
+            String message = "Error creating local entry. Couldn't decode string.";
+            LOGGER.error("{} Base64 encoded xml: {}", message, base64EncodedXmlData);
+            throw new FederationAdminException(message, e);
+        }
+        return metacardId;
+    }
+
+    @Override
+    public void updateLocalEntry(Map<String, Object> registryObjectMap)
+            throws FederationAdminException {
+        if (MapUtils.isEmpty(registryObjectMap)) {
+            throw new FederationAdminException(
+                    "Error updating local registry entry. Null map provided.");
+        }
+        RegistryPackageType registryPackage =
+                RegistryPackageWebConverter.getRegistryPackageFromWebMap(registryObjectMap);
+
+        if (registryPackage == null) {
+            String message =
+                    "Error updating local registry entry. Couldn't convert registry map to a registry package.";
+            LOGGER.error("{} Registry Map: {}", message, registryObjectMap);
+            throw new FederationAdminException(message);
+        }
+
+        List<Metacard> existingMetacards =
+                federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                        registryPackage.getId()));
+
+        if (CollectionUtils.isEmpty(existingMetacards)) {
+            String message = "Error updating local registry entry. Registry metacard not found.";
+            LOGGER.error("{} Registry ID: {}", message, registryPackage.getId());
+            throw new FederationAdminException(message);
+        }
+
+        if (existingMetacards.size() > 1) {
+            String message =
+                    "Error updating local registry entry. Multiple registry metacards found.";
+
+            List<String> metacardIds = new ArrayList<>();
+            metacardIds.addAll(existingMetacards.stream()
+                    .map(Metacard::getId)
+                    .collect(Collectors.toList()));
+            LOGGER.error("{} Matching registry metacard ids: {}", message, metacardIds);
+
+            throw new FederationAdminException(message);
+        }
+        Metacard existingMetacard = existingMetacards.get(0);
+
+        Metacard updateMetacard = getRegistryMetacardFromRegistryPackage(registryPackage);
+        updateMetacard.setAttribute(new AttributeImpl(Metacard.ID, existingMetacard.getId()));
+
+        federationAdminService.updateRegistryEntry(updateMetacard);
+    }
+
+    @Override
+    public void deleteLocalEntry(List<String> ids) throws FederationAdminException {
+        if (CollectionUtils.isEmpty(ids)) {
+            throw new FederationAdminException(
+                    "Error deleting local registry entries. No ids provided.");
+        }
+
+        List<Metacard> localMetacards =
+                federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids);
+        List<String> metacardIds = new ArrayList<>();
+
+        metacardIds.addAll(localMetacards.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList()));
+        if (ids.size() != metacardIds.size()) {
+            String message = "Error deleting local registry entries. Registry ids provided.";
+            LOGGER.error("{} Registry Ids provided: {}. Registry metacard ids found: {}",
+                    message,
+                    ids,
+                    metacardIds);
+            throw new FederationAdminException(message);
+        }
+
+        federationAdminService.deleteRegistryEntriesByMetacardIds(metacardIds);
+    }
+
+    @Override
+    public Map<String, Object> getLocalNodes() throws FederationAdminException {
+        Map<String, Object> localNodes = new HashMap<>();
+        List<Map<String, Object>> registryWebMaps = new ArrayList<>();
+
+        List<RegistryPackageType> registryPackages =
+                federationAdminService.getLocalRegistryObjects();
+        registryWebMaps.addAll(registryPackages.stream()
+                .map(RegistryPackageWebConverter::getRegistryObjectWebMap)
+                .collect(Collectors.toList()));
+
+        localNodes.put("localNodes", registryWebMaps);
+
+        return localNodes;
+    }
+
+    private Metacard getRegistryMetacardFromRegistryPackage(RegistryPackageType registryPackage)
+            throws FederationAdminException {
+        if (registryPackage == null) {
+            throw new FederationAdminException(
+                    "Error creating metacard from registry package. Null package was received.");
+        }
+        Metacard metacard;
+
+        try {
+            JAXBElement<RegistryPackageType> jaxbRegistryObjectType =
+                    RIM_FACTORY.createRegistryPackage(registryPackage);
+
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            parser.marshal(marshalConfigurator, jaxbRegistryObjectType, baos);
+            InputStream xmlInputStream = new ByteArrayInputStream(baos.toByteArray());
+            metacard = registryTransformer.transform(xmlInputStream);
+
+        } catch (IOException | CatalogTransformerException | ParserException e) {
+            String message = "Error creating metacard from registry package.";
+            LOGGER.error("{} Registry id: {}", message, registryPackage.getId());
+            throw new FederationAdminException(message, e);
+        }
+
+        return metacard;
+    }
+
+    private Metacard getRegistryMetacardFromInputStream(InputStream inputStream)
+            throws FederationAdminException {
+        if (inputStream == null) {
+            throw new FederationAdminException(
+                    "Error converting input stream to a metacard. Null input stream provided.");
+        }
+
+        Metacard metacard;
+        try {
+            metacard = registryTransformer.transform(inputStream);
+        } catch (IOException | CatalogTransformerException e) {
+            throw new FederationAdminException(
+                    "Error getting metacard. RegistryTransformer couldn't convert the input stream.",
+                    e);
+        }
+
+        return metacard;
+    }
+
+    private void configureMBean() {
+        mbeanServer = ManagementFactory.getPlatformMBeanServer();
+
+        try {
+            objectName = new ObjectName(FederationAdminMBean.OBJECT_NAME);
+        } catch (MalformedObjectNameException e) {
+            LOGGER.warn("Exception while creating object name: " + FederationAdminMBean.OBJECT_NAME,
+                    e);
+        }
+
+        try {
+            try {
+                mbeanServer.registerMBean(new StandardMBean(this, FederationAdminMBean.class),
+                        objectName);
+            } catch (InstanceAlreadyExistsException e) {
+                mbeanServer.unregisterMBean(objectName);
+                mbeanServer.registerMBean(new StandardMBean(this, FederationAdminMBean.class),
+                        objectName);
+            }
+        } catch (Exception e) {
+            LOGGER.error("Could not register mbean.", e);
+        }
+    }
+
+    public void destroy() {
+        try {
+            if (objectName != null && mbeanServer != null) {
+                mbeanServer.unregisterMBean(objectName);
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Exception un registering mbean: ", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void setFederationAdminService(FederationAdminService federationAdminService) {
+        this.federationAdminService = federationAdminService;
+    }
+
+    public void setParser(Parser parser) {
+        List<String> contextPath = Arrays.asList(RegistryObjectType.class.getPackage()
+                        .getName(),
+                net.opengis.ogc.ObjectFactory.class.getPackage()
+                        .getName(),
+                net.opengis.gml.v_3_1_1.ObjectFactory.class.getPackage()
+                        .getName());
+
+        ClassLoader classLoader = this.getClass()
+                .getClassLoader();
+
+        this.marshalConfigurator = parser.configureParser(contextPath, classLoader);
+        this.marshalConfigurator.addProperty(Marshaller.JAXB_FRAGMENT, true);
+
+        this.parser = parser;
+    }
+
+    public void setRegistryTransformer(InputTransformer inputTransformer) {
+        this.registryTransformer = inputTransformer;
+    }
+}

--- a/catalog/registry/catalog-registry-federationadminimpl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/registry/catalog-registry-federationadminimpl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,31 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd">
+
+    <bean id="federationAdmin" class="ddf.catalog.registry.federationadmin.impl.FederationAdmin"
+          destroy-method="destroy">
+        <property name="federationAdminService" ref="federationAdminService"/>
+        <property name="registryTransformer" ref="inputTransformer"/>
+        <property name="parser" ref="xmlParser"/>
+    </bean>
+
+    <reference id="federationAdminService"
+               interface="ddf.catalog.registry.federationadmin.service.FederationAdminService"/>
+    <reference id="inputTransformer" interface="ddf.catalog.transform.InputTransformer"
+               filter="(id=rim:RegistryPackage)"/>
+    <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"/>
+
+</blueprint>

--- a/catalog/registry/catalog-registry-federationadminimpl/src/test/java/ddf/catalog/registry/federationadmin/converter/RegistryPackageWebConverterTest.java
+++ b/catalog/registry/catalog-registry-federationadminimpl/src/test/java/ddf/catalog/registry/federationadmin/converter/RegistryPackageWebConverterTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.registry.federationadmin.converter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.bind.JAXBElement;
+
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.ParserConfigurator;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.parser.xml.XmlParser;
+import org.junit.Before;
+import org.junit.Test;
+
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+
+public class RegistryPackageWebConverterTest {
+    private Parser parser;
+
+    private ParserConfigurator configurator;
+
+    @Before
+    public void setUp() {
+        parser = new XmlParser();
+
+        configurator = parser.configureParser(Arrays.asList(RegistryObjectType.class.getPackage()
+                        .getName(),
+                net.opengis.ogc.ObjectFactory.class.getPackage()
+                        .getName(),
+                net.opengis.gml.v_3_1_1.ObjectFactory.class.getPackage()
+                        .getName()),
+                this.getClass()
+                        .getClassLoader());
+    }
+
+    @Test
+    public void testRoundTrip() throws Exception {
+        RegistryObjectType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+
+        Map<String, Object> registryMap = RegistryPackageWebConverter.getRegistryObjectWebMap(
+                registryObject);
+
+        RegistryObjectType convertedRegistryObject =
+                RegistryPackageWebConverter.getRegistryPackageFromWebMap(registryMap);
+
+        assertThat(registryObject.getObjectType(),
+                is(equalTo(convertedRegistryObject.getObjectType())));
+        assertThat(registryObject.getId(), is(equalTo(convertedRegistryObject.getId())));
+        assertThat(registryObject.getHome(), is(equalTo(convertedRegistryObject.getHome())));
+        assertThat(registryObject.getExternalIdentifier(),
+                is(equalTo(convertedRegistryObject.getExternalIdentifier())));
+        assertThat(((RegistryPackageType) registryObject).getRegistryObjectList()
+                        .getIdentifiable()
+                        .size(),
+                is(equalTo(((RegistryPackageType) convertedRegistryObject).getRegistryObjectList()
+                        .getIdentifiable()
+                        .size())));
+
+        // Skipping some of these because the xml to object dates are stored as strings
+        // and the converted values for the same are stored as Date objects so they don't match.
+        List<Integer> indexes = Arrays.asList(4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15);
+        for (int i : indexes) {
+            assertThat(((RegistryPackageType) registryObject).getRegistryObjectList()
+                            .getIdentifiable()
+                            .get(i)
+                            .getValue(),
+                    is(equalTo(((RegistryPackageType) convertedRegistryObject).getRegistryObjectList()
+                            .getIdentifiable()
+                            .get(i)
+                            .getValue())));
+        }
+    }
+
+    private RegistryObjectType getRegistryObjectFromResource(String path) throws ParserException {
+        RegistryObjectType registryObject = null;
+        JAXBElement<RegistryObjectType> jaxbRegistryObject = parser.unmarshal(configurator,
+                JAXBElement.class,
+                getClass().getResourceAsStream(path));
+
+        if (jaxbRegistryObject != null) {
+            registryObject = jaxbRegistryObject.getValue();
+        }
+
+        return registryObject;
+    }
+
+}

--- a/catalog/registry/catalog-registry-federationadminimpl/src/test/java/ddf/catalog/registry/federationadmin/impl/FederationAdminTest.java
+++ b/catalog/registry/catalog-registry-federationadminimpl/src/test/java/ddf/catalog/registry/federationadmin/impl/FederationAdminTest.java
@@ -1,0 +1,475 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package ddf.catalog.registry.federationadmin.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.xml.bind.JAXBElement;
+
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.ParserConfigurator;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.parser.xml.XmlParser;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import ddf.catalog.data.Metacard;
+import ddf.catalog.data.impl.AttributeImpl;
+import ddf.catalog.data.impl.MetacardImpl;
+import ddf.catalog.registry.common.metacard.RegistryObjectMetacardType;
+import ddf.catalog.registry.federationadmin.converter.RegistryPackageWebConverter;
+import ddf.catalog.registry.federationadmin.service.FederationAdminException;
+import ddf.catalog.registry.federationadmin.service.FederationAdminService;
+import ddf.catalog.registry.transformer.RegistryTransformer;
+import ddf.catalog.transform.CatalogTransformerException;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FederationAdminTest {
+    @Mock
+    private FederationAdminService federationAdminService;
+
+    private FederationAdmin federationAdmin;
+
+    @Mock
+    private Parser mockParser;
+
+    @Mock
+    private ParserConfigurator mockConfigurator;
+
+    private Parser parser;
+
+    private ParserConfigurator configurator;
+
+    @Mock
+    private RegistryTransformer registryTransformer;
+
+    private static final String LOCAL_NODE_KEY = "localNodes";
+
+    @Before
+    public void setUp() {
+        parser = new XmlParser();
+        configurator = parser.configureParser(Arrays.asList(RegistryObjectType.class.getPackage()
+                        .getName(),
+                net.opengis.ogc.ObjectFactory.class.getPackage()
+                        .getName(),
+                net.opengis.gml.v_3_1_1.ObjectFactory.class.getPackage()
+                        .getName()),
+                this.getClass()
+                        .getClassLoader());
+
+        when(mockParser.configureParser(anyList(), any(ClassLoader.class))).thenReturn(
+                mockConfigurator);
+        federationAdmin = new FederationAdmin();
+        federationAdmin.setFederationAdminService(federationAdminService);
+        federationAdmin.setRegistryTransformer(registryTransformer);
+        federationAdmin.setParser(mockParser);
+    }
+
+    @Test
+    public void testCreateLocalEntry() throws Exception {
+        String metacardId = "metacardId";
+        RegistryObjectType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+
+        Metacard metacard = getTestMetacard();
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(federationAdminService.addRegistryEntry(any(Metacard.class))).thenReturn(metacardId);
+
+        String createdMetacardId = federationAdmin.createLocalEntry(registryMap);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(federationAdminService).addRegistryEntry(metacard);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryWithEmptyMap() throws Exception {
+        Map<String, Object> registryMap = new HashMap<>();
+        federationAdmin.createLocalEntry(registryMap);
+
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryWithBadMap() throws Exception {
+        Map<String, Object> registryMap = new HashMap<>();
+        registryMap.put("BadKey", "BadValue");
+
+        federationAdmin.createLocalEntry(registryMap);
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryWithFederationAdminException() throws Exception {
+        RegistryObjectType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+
+        Metacard metacard = getTestMetacard();
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(federationAdminService.addRegistryEntry(any(Metacard.class))).thenThrow(
+                FederationAdminException.class);
+
+        federationAdmin.createLocalEntry(registryMap);
+
+        verify(federationAdminService).addRegistryEntry(metacard);
+    }
+
+    @Test
+    public void testCreateLocalEntryString() throws Exception {
+        String encodeThisString = "aPretendXmlRegistryPackage";
+        String metacardId = "createdMetacardId";
+        String base64EncodedString = Base64.getEncoder()
+                .encodeToString(encodeThisString.getBytes());
+
+        Metacard metacard = getTestMetacard();
+
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(federationAdminService.addRegistryEntry(metacard)).thenReturn(metacardId);
+
+        String createdMetacardId = federationAdmin.createLocalEntry(base64EncodedString);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(federationAdminService).addRegistryEntry(metacard);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryStringWithBlankString() throws Exception {
+        String base64EncodedString = "";
+
+        federationAdmin.createLocalEntry(base64EncodedString);
+
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryStringWithTransformerException() throws Exception {
+        String encodeThisString = "aPretendXmlRegistryPackage";
+        String base64EncodedString = Base64.getEncoder()
+                .encodeToString(encodeThisString.getBytes());
+
+        when(registryTransformer.transform(any(InputStream.class))).thenThrow(
+                CatalogTransformerException.class);
+
+        federationAdmin.createLocalEntry(base64EncodedString);
+
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testCreateLocalEntryStringWithDecodeError() throws Exception {
+        // This is has an illegal base64 character
+        String base64EncodedString = "[B@6499375d";
+
+        federationAdmin.createLocalEntry(base64EncodedString);
+
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).addRegistryEntry(any(Metacard.class));
+    }
+
+    @Test
+    public void testUpdateLocalEntry() throws Exception {
+        RegistryObjectType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        String existingMetacardId = "someUpdateMetacardId";
+
+        Metacard existingMetacard = getTestMetacard();
+        existingMetacard.setAttribute(new AttributeImpl(Metacard.ID, existingMetacardId));
+        List<Metacard> existingMetacards = new ArrayList<>();
+        existingMetacards.add(existingMetacard);
+        Metacard updateMetacard = getTestMetacard();
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()))).thenReturn(existingMetacards);
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(updateMetacard);
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()));
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(federationAdminService).updateRegistryEntry(updateMetacard);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithEmptyMap() throws Exception {
+        Map<String, Object> registryMap = new HashMap<>();
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService,
+                never()).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(any(String.class)));
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).updateRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithBadMap() throws Exception {
+        Map<String, Object> registryMap = new HashMap<>();
+        registryMap.put("BadKey", "BadValue");
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService,
+                never()).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(any(String.class)));
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).updateRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithEmptyExistingList() throws Exception {
+        RegistryObjectType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        List<Metacard> existingMetacards = new ArrayList<>();
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()))).thenReturn(existingMetacards);
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService,
+                never()).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()));
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).updateRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithMultipleExistingMetacards() throws Exception {
+        RegistryObjectType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        List<Metacard> existingMetacards = new ArrayList<>();
+        existingMetacards.add(getTestMetacard());
+        existingMetacards.add(getTestMetacard());
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()))).thenReturn(existingMetacards);
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService,
+                never()).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()));
+        verify(registryTransformer, never()).transform(any(InputStream.class));
+        verify(federationAdminService, never()).updateRegistryEntry(any(Metacard.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateLocalEntryWithFederationAdminServiceException() throws Exception {
+        RegistryObjectType registryObject = getRegistryObjectFromResource(
+                "/csw-full-registry-package.xml");
+        Map<String, Object> registryMap = getMapFromRegistryObject(registryObject);
+        String existingMetacardId = "someUpdateMetacardId";
+
+        Metacard existingMetacard = getTestMetacard();
+        existingMetacard.setAttribute(new AttributeImpl(Metacard.ID, existingMetacardId));
+        List<Metacard> existingMetacards = new ArrayList<>();
+        existingMetacards.add(existingMetacard);
+        Metacard updateMetacard = getTestMetacard();
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()))).thenReturn(existingMetacards);
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(updateMetacard);
+        doThrow(FederationAdminException.class).when(federationAdminService)
+                .updateRegistryEntry(updateMetacard);
+
+        federationAdmin.updateLocalEntry(registryMap);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(Collections.singletonList(
+                registryObject.getId()));
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(federationAdminService).updateRegistryEntry(updateMetacard);
+    }
+
+    @Test
+    public void testDeleteLocalEntry() throws Exception {
+        String firstRegistryId = "firstRegistryId";
+        String secondRegistryId = "secondRegistryId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstRegistryId);
+        ids.add(secondRegistryId);
+
+        String firstMetacardId = "firstMetacardId";
+        String secondMetacardId = "secondMetacardId";
+
+        Metacard firstMetacard = getTestMetacard();
+        firstMetacard.setAttribute(new AttributeImpl(Metacard.ID, firstMetacardId));
+        Metacard secondMetacard = getTestMetacard();
+        secondMetacard.setAttribute(new AttributeImpl(Metacard.ID, secondMetacardId));
+
+        List<Metacard> matchingMetacards = new ArrayList<>();
+        matchingMetacards.add(firstMetacard);
+        matchingMetacards.add(secondMetacard);
+
+        List<String> metacardIds = new ArrayList<>();
+        metacardIds.addAll(matchingMetacards.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList()));
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids)).thenReturn(
+                matchingMetacards);
+
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(ids);
+        verify(federationAdminService).deleteRegistryEntriesByMetacardIds(metacardIds);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteLocalEntryWithEmptyList() throws Exception {
+        List<String> ids = new ArrayList<>();
+
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService, never()).getLocalRegistryMetacardsByRegistryIds(anyList());
+        verify(federationAdminService, never()).deleteRegistryEntriesByMetacardIds(anyList());
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteLocalEntryWithExceptionGettingLocalMetacards() throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("whatever");
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids)).thenThrow(
+                FederationAdminException.class);
+
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(ids);
+        verify(federationAdminService, never()).deleteRegistryEntriesByMetacardIds(anyList());
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteLocalEntryWithNonMatchingLists() throws Exception {
+        String firstRegistryId = "firstRegistryId";
+        String secondRegistryId = "secondRegistryId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstRegistryId);
+        ids.add(secondRegistryId);
+
+        String firstMetacardId = "firstMetacardId";
+
+        Metacard firstMetacard = getTestMetacard();
+        firstMetacard.setAttribute(new AttributeImpl(Metacard.ID, firstMetacardId));
+
+        List<Metacard> matchingMetacards = new ArrayList<>();
+        matchingMetacards.add(firstMetacard);
+
+        List<String> metacardIds = new ArrayList<>();
+        metacardIds.addAll(matchingMetacards.stream()
+                .map(Metacard::getId)
+                .collect(Collectors.toList()));
+
+        when(federationAdminService.getLocalRegistryMetacardsByRegistryIds(ids)).thenReturn(
+                matchingMetacards);
+
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService).getLocalRegistryMetacardsByRegistryIds(ids);
+        verify(federationAdminService, never()).deleteRegistryEntriesByMetacardIds(metacardIds);
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteLocalEntryWithExceptionDeletingEntries() throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("firstId");
+
+        doThrow(FederationAdminException.class).when(federationAdminService)
+                .deleteRegistryEntriesByRegistryIds(ids);
+        federationAdmin.deleteLocalEntry(ids);
+
+        verify(federationAdminService).deleteRegistryEntriesByRegistryIds(ids);
+    }
+
+    @Test
+    public void testGetLocalNodes() throws Exception {
+        RegistryObjectType registryObject = getRegistryObjectFromResource(
+                "/csw-registry-package-smaller.xml");
+        Map<String, Object> registryObjectMap = RegistryPackageWebConverter.getRegistryObjectWebMap(
+                registryObject);
+        List<RegistryPackageType> registryPackages = new ArrayList<>();
+        registryPackages.add((RegistryPackageType) registryObject);
+
+        when(federationAdminService.getLocalRegistryObjects()).thenReturn(registryPackages);
+        Map<String, Object> localNodes = federationAdmin.getLocalNodes();
+
+        Map<String, Object> localNode =
+                ((List<Map<String, Object>>) localNodes.get(LOCAL_NODE_KEY)).get(0);
+        verify(federationAdminService).getLocalRegistryObjects();
+        assertThat(localNode, is(equalTo(registryObjectMap)));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalNodesWithFederationAdminException() throws Exception {
+        when(federationAdminService.getLocalRegistryObjects()).thenThrow(FederationAdminException.class);
+
+        federationAdmin.getLocalNodes();
+
+        verify(federationAdminService).getLocalRegistryObjects();
+    }
+
+    private RegistryObjectType getRegistryObjectFromResource(String path) throws ParserException {
+        RegistryObjectType registryObject = null;
+        JAXBElement<RegistryObjectType> jaxbRegistryObject = parser.unmarshal(configurator,
+                JAXBElement.class,
+                getClass().getResourceAsStream(path));
+
+        if (jaxbRegistryObject != null) {
+            registryObject = jaxbRegistryObject.getValue();
+        }
+
+        return registryObject;
+    }
+
+    private Map<String, Object> getMapFromRegistryObject(RegistryObjectType registryObject) {
+        return RegistryPackageWebConverter.getRegistryObjectWebMap(registryObject);
+    }
+
+    private RegistryPackageType getRegistryObjectFromMap(Map<String, Object> registryMap) {
+        return RegistryPackageWebConverter.getRegistryPackageFromWebMap(registryMap);
+    }
+
+    private Metacard getTestMetacard() {
+        return new MetacardImpl(new RegistryObjectMetacardType());
+    }
+}

--- a/catalog/registry/catalog-registry-federationadminimpl/src/test/resources/csw-full-registry-package.xml
+++ b/catalog/registry/catalog-registry-federationadminimpl/src/test/resources/csw-full-registry-package.xml
@@ -1,0 +1,391 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<!-- This example csw-ebrim message represents a single node in a system. The ddf registry is not a ebrim registry but uses the csw ebrim format to hold and transmit registry information. In
+     a sense each node contains its own ebrim registry less the canonical classifications. The full registry package and all its RegistryObjects are stored in one metacard. In places where
+     you might reference a pre existing ClassificationNode or ClassificationSchema as defined in a standard ebrim registry we have opted to just use string identifiers that are consistent
+     with the canonical classification nodes. Associations are used to associate the various object. Primarily associations are ued to associate organizations and people with content collections,
+     services and the general node description. Each of the user defined id's (not the framework generated ones) are arbitrary and are only required to be unique in the document. The top level
+     objects id should be a uuid that is globally unique-->
+<!-- top level registry object id is turned into the regsitry-id internally. metacard content type will be set using the lid.-->
+<!-- home attribute should be set by the framework to the base url of the originating instance -->
+<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+                     xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                     xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
+                     xmlns:gml="http://www.opengis.net/gml">
+
+    <!-- external identifiers are set by the framework to track the local metacard id and the origin-id. origin-id is the metacard id of the registry entry on the originating instance-->
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+
+    <!-- RegistryObjectList holds all the actual registry content-->
+    <rim:RegistryObjectList>
+        <!-- defines the general node information -->
+        <rim:ExtrinsicObject id="urn:registry:node" objectType="urn:registry:federation:node">
+            <!--Optional: Date indicating when this instance when live or operational-->
+            <rim:Slot name="liveDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-11-01T06:15:30-07:00</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating the earliest data sets available in this instance-->
+            <rim:Slot name="dataStartDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-11-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating when data stopped being added to this instance-->
+            <rim:Slot name="dataEndDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-12-01T23:01:40Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!-- Date this entries data was last updated/created by its originator -->
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Any links that might be associated with this instance like wiki pages -->
+            <rim:Slot name="links" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>https://some/link/to/my/repo</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Geographic location of this instance described by a gml:Point-->
+            <rim:Slot name="location" slotType="urn:ogc:def:dataType:ISO-19107:2003:GM_Point">
+                <wrs:ValueList>
+                    <wrs:AnyValue>
+                        <gml:Point srsDimension="2" srsName="urn:ogc:def:crs:EPSG::4326">
+                            <gml:pos>112.267472 33.467944</gml:pos>
+                        </gml:Point>
+                    </wrs:AnyValue>
+                </wrs:ValueList>
+            </rim:Slot>
+            <!--Optional: Region of this instance described by a UNSD region. The location should be within this region -->
+            <rim:Slot name="region" slotType="urn:ogc:def:ebRIM-ClassificationScheme:UNSD:GlobalRegions">
+                <rim:ValueList>
+                    <rim:Value>USA</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!--Optional: Sorces of information that contribute to this instances data-->
+            <rim:Slot name="inputDataSources" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>youtube</rim:Value>
+                    <rim:Value>myCamera</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Types of data that this instance contains-->
+            <rim:Slot name="dataTypes" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>video</rim:Value>
+                    <rim:Value>sensor</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: String representing the security level of this instance-->
+            <rim:Slot name="securityLevel" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>role=guest</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!-- Name used primarily for display in UI interfaces to uniquely identify this node -->
+            <rim:Name>
+                <rim:LocalizedString value="Node Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+            </rim:Description>
+            <rim:VersionInfo versionName="2.9.x"/>
+            <rim:Classification id="urn:classification:id0" classifiedObject="classifiedObjectId"/>
+        </rim:ExtrinsicObject>
+
+        <!-- all extrinsic objects with lid=urn:registry:content:collection will be used to create content collections -->
+        <rim:ExtrinsicObject id="urn:content:collection:id0" objectType="urn:registry:content:collection">
+
+            <rim:Slot name="types" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>sensor</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Slot name="mimeTypes" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>application/pdf</rim:Value>
+                    <rim:Value>application/msword</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Slot name="recordCount" slotType="xs:long">
+                <rim:ValueList>
+                    <rim:Value>1234</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!--Optional: Date indicating the earliest data sets available in this collection-->
+            <rim:Slot name="startDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-11-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating when data stopped being added to this collection-->
+            <rim:Slot name="endDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-12-01T23:01:40Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: A gml feature describing the geographic bounds of the data contained in this collection-->
+            <rim:Slot name="bounds" slotType="urn:ogc:def:dataType:ISO-19107:2003:GM_Envelope">
+                <wrs:ValueList>
+                    <wrs:AnyValue>
+                        <gml:Envelope srsName="urn:ogc:def:crs:EPSG:4326">
+                            <gml:lowerCorner>60.042 13.754</gml:lowerCorner>
+                            <gml:upperCorner>68.410 17.920</gml:upperCorner>
+                        </gml:Envelope>
+                    </wrs:AnyValue>
+                </wrs:ValueList>
+            </rim:Slot>
+            <!--Optional: A UNSD region  describing the geographic bounds of the data contained in this collection-->
+            <rim:Slot name="region"
+                      slotType="urn:ogc:def:ebRIM-ClassificationScheme:UNSD:GlobalRegions">
+                <rim:ValueList>
+                    <rim:Value>Arizona</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Name>
+                <rim:LocalizedString value="Collection Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this collection in less than 1024 characters"/>
+            </rim:Description>
+        </rim:ExtrinsicObject>
+
+        <rim:ExtrinsicObject id="urn:content:collection:id1" objectType="urn:registry:content:collection">
+            <rim:Slot name="types" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>video</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Slot name="mimeTypes" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>video/mpeg4-generic</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <rim:Slot name="recordCount" slotType="xs:long">
+                <rim:ValueList>
+                    <rim:Value>1234</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating the earliest data sets available in this collection-->
+            <rim:Slot name="startDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-11-01T13:15:30Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Date indicating when data stopped being added to this collection-->
+            <rim:Slot name="endDate" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2015-12-01T22:01:40Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Slot name="lastUpdated" slotType="xs:dateTime">
+                <rim:ValueList>
+                    <rim:Value>2016-01-26T17:16:34.996Z</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <rim:Name>
+                <rim:LocalizedString value="Collection Name2"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this collection in less than 1024 characters"/>
+            </rim:Description>
+        </rim:ExtrinsicObject>
+
+        <rim:ExtrinsicObject id="urn:service:params:id0" mimeType="application/octet-stream" isOpaque="false">
+            <rim:ContentVersionInfo comment="someComment" versionName="versionName"/>
+            <rim:Slot name="parameters">
+                <rim:ValueList>
+                    <rim:Value>param1</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+        </rim:ExtrinsicObject>
+
+        <!-- There should be only one service defined with lid=urn:registry:federation:service. Multiple service bindings can be added to this one service -->
+        <rim:Service id="urn:service:id0" objectType="urn:registry:federation:service">
+            <!--
+            Zero or more repetitions: Service bindings represent a way to query data
+            from this instance. Each binding can have one or more slots that define URLs or other properties.
+            For more complex properties such as query parameters use specification links to point to an
+            ExtrinsicObject that contains the required information. For federation source creation all the
+            serviceBinding slots and name will be used as properties for creating the source. Which source is
+            created will be based on the bindingType attribute which should be the factory pid of a managed service factory
+            -->
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276">
+                <!--Slot defining the query url for this particular method of communicating with this instance-->
+                <rim:Slot name="cswUrl" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <!-- bindingType identifies communication message type for this binding-->
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>Csw_Federated_Source</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="serviceType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>REST</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="endpointDocumentation" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/path/to/docs.html</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Name>
+                    <rim:LocalizedString value="CSW Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the CSW federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="2.0.2"/>
+
+                <!-- SpecificationLinks are also RegistryObjects so if needed slots can be added directly to them. If possible use an ExtrinsicObject instead.-->
+                <rim:SpecificationLink id="urn:request:parameters" serviceBinding="urn:registry:federation:method:csw" specificationObject="urn:service:params:id0"/>
+            </rim:ServiceBinding>
+            <rim:ServiceBinding id="urn:registry:federation:method:soap13"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276"
+                                accessURI="some:access:URI:any:URI" targetBinding="some:target:binding:reference:URI">
+                <rim:Slot name="queryAddress" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="ingestAddress" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="eventAddress" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>soap13</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="serviceType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>SOAP</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="endpointDocumentation" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/path/to/docs.html</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Name>
+                    <rim:LocalizedString value="Soap Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the Soap federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="1.3"/>
+                <rim:SpecificationLink id="notARealId" serviceBinding="notARealServiceBinding"
+                                       specificationObject="notARealSpecificationObject">
+                    <rim:UsageDescription>
+                        <rim:LocalizedString value="This is some usage description"/>
+                    </rim:UsageDescription>
+                    <rim:UsageParameter>
+                        "someUsageParameter"
+                    </rim:UsageParameter>
+                </rim:SpecificationLink>
+            </rim:ServiceBinding>
+        </rim:Service>
+
+        <rim:Organization id="urn:organization:id0"
+                          parent="urn:uuid:2014ca7f59ac46f495e32b4a67a51276"
+                          primaryContact="somePrimaryContact"
+                          lid="someLid"
+                          status="someStatus">
+            <rim:Name>
+                <rim:LocalizedString value="Codice"/>
+            </rim:Name>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street"/>
+            <rim:TelephoneNumber areaCode="555" number="555-5555" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+            <rim:Classification id="urn:classification:id0" classifiedObject="classifiedObjectId" classificationScheme="classificationScheme" classificationNode="classificationNode" nodeRepresentation="nodeRepresentation"/>
+        </rim:Organization>
+
+        <rim:Organization id="urn:organization:id1"
+                          parent="urn:uuid:2014ca7f59ac46f495e32b4a67a51276">
+            <rim:Name>
+                <rim:LocalizedString value="MyOrg"/>
+            </rim:Name>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street"/>
+            <rim:TelephoneNumber areaCode="555" number="555-5555" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com" type="SomeEmailAddressType"/>
+        </rim:Organization>
+
+        <rim:Person id="urn:contact:id0" >
+            <rim:PersonName firstName="john" middleName="middleName" lastName="doe"/>
+            <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234" countryCode="country" phoneType="cell phone"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street" streetNumber="1234"/>
+        </rim:Person>
+
+        <rim:Person id="urn:contact:id1">
+            <rim:PersonName firstName="john1" lastName="doe1"/>
+            <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+        </rim:Person>
+
+        <rim:Person id="urn:contact:id2">
+            <rim:PersonName firstName="john2" lastName="doe2"/>
+            <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+        </rim:Person>
+
+        <!-- An organization or person associated with the 'registry.node' will be set as the overall metacards organization and contact. If there is more than one organization or person associated
+        with the registry.node the first assocaition will be used. If no association is made to the registry.node the first organization or contact found will be used-->
+        <rim:Association id="urn:assoication:1" associationType="RelatedTo" sourceObject="urn:registry:node" targetObject="urn:contact:id0"/>
+        <rim:Association id="urn:assoication:2" associationType="RelatedTo" sourceObject="urn:registry:node" targetObject="urn:organization:id0"/>
+        <rim:Association id="urn:assoication:3" associationType="RelatedTo" sourceObject="urn:contact:person1" targetObject="urn:content:collection:id0"/>
+        <rim:Association id="urn:assoication:4" associationType="RelatedTo" sourceObject="urn:contact:person2" targetObject="urn:content:collection:id1"/>
+        <rim:Association id="urn:assoication:5" associationType="RelatedTo" sourceObject="urn:organization:id1" targetObject="urn:service:id0"/>
+        <rim:Association id="urn:assoication:6" associationType="RelatedTo" sourceObject="urn:organization:id0" targetObject="urn:content:collection:id0"/>
+
+    </rim:RegistryObjectList>
+</rim:RegistryPackage>

--- a/catalog/registry/catalog-registry-federationadminimpl/src/test/resources/csw-registry-package-smaller.xml
+++ b/catalog/registry/catalog-registry-federationadminimpl/src/test/resources/csw-registry-package-smaller.xml
@@ -1,0 +1,169 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<!-- This example csw-ebrim message represents a single node in a system. The ddf registry is not a ebrim registry but uses the csw ebrim format to hold and transmit registry information. In
+     a sense each node contains its own ebrim registry less the canonical classifications. The full registry package and all its RegistryObjects are stored in one metacard. In places where
+     you might reference a pre existing ClassificationNode or ClassificationSchema as defined in a standard ebrim registry we have opted to just use string identifiers that are consistent
+     with the canonical classification nodes. Associations are used to associate the various object. Primarily associations are ued to associate organizations and people with content collections,
+     services and the general node description. Each of the user defined id's (not the framework generated ones) are arbitrary and are only required to be unique in the document. The top level
+     objects id should be a uuid that is globally unique-->
+<!-- top level registry object id is turned into the regsitry-id internally. metacard content type will be set using the lid.-->
+<!-- home attribute should be set by the framework to the base url of the originating instance -->
+<rim:RegistryPackage id="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" home="https://somehost:someport" objectType="urn:registry:federation:node"
+                     xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0"
+                     xmlns:wrs="http://www.opengis.net/cat/wrs/1.0"
+                     xmlns:gml="http://www.opengis.net/gml">
+
+    <!-- external identifiers are set by the framework to track the local metacard id and the origin-id. origin-id is the metacard id of the registry entry on the originating instance-->
+    <rim:ExternalIdentifier id="urn:mcard:local-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+    <rim:ExternalIdentifier id="urn:mcard:origin-id" registryObject="urn:uuid:2014ca7f59ac46f495e32b4a67a51276" identificationScheme="MetacardId" value="someUUID"/>
+
+    <!-- RegistryObjectList holds all the actual registry content-->
+    <rim:RegistryObjectList>
+        <!-- defines the general node information -->
+        <rim:ExtrinsicObject id="urn:registry:node" objectType="urn:registry:federation:node">
+            <!--Optional: Any links that might be associated with this instance like wiki pages -->
+            <rim:Slot name="links" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>https://some/link/to/my/repo</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Geographic location of this instance described by a gml:Point-->
+            <rim:Slot name="location" slotType="urn:ogc:def:dataType:ISO-19107:2003:GM_Point">
+                <wrs:ValueList>
+                    <wrs:AnyValue>
+                        <gml:Point srsDimension="2" srsName="urn:ogc:def:crs:EPSG::4326">
+                            <gml:pos>112.267472 33.467944</gml:pos>
+                        </gml:Point>
+                    </wrs:AnyValue>
+                </wrs:ValueList>
+            </rim:Slot>
+            <!--Optional: Region of this instance described by a UNSD region. The location should be within this region -->
+            <rim:Slot name="region" slotType="urn:ogc:def:ebRIM-ClassificationScheme:UNSD:GlobalRegions">
+                <rim:ValueList>
+                    <rim:Value>USA</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!--Optional: Sorces of information that contribute to this instances data-->
+            <rim:Slot name="inputDataSources" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>youtube</rim:Value>
+                    <rim:Value>myCamera</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: Types of data that this instance contains-->
+            <rim:Slot name="dataTypes" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>video</rim:Value>
+                    <rim:Value>sensor</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+            <!--Optional: String representing the security level of this instance-->
+            <rim:Slot name="securityLevel" slotType="xs:string">
+                <rim:ValueList>
+                    <rim:Value>role=guest</rim:Value>
+                </rim:ValueList>
+            </rim:Slot>
+
+            <!-- Name used primarily for display in UI interfaces to uniquely identify this node -->
+            <rim:Name>
+                <rim:LocalizedString value="Node Name"/>
+            </rim:Name>
+            <rim:Description>
+                <rim:LocalizedString value="A little something describing this node in less than 1024 characters"/>
+            </rim:Description>
+            <rim:VersionInfo versionName="2.9.x"/>
+            <rim:Classification id="urn:classification:id0" classifiedObject="classifiedObjectId"/>
+        </rim:ExtrinsicObject>
+
+        <!-- There should be only one service defined with lid=urn:registry:federation:service. Multiple service bindings can be added to this one service -->
+        <rim:Service id="urn:service:id0" objectType="urn:registry:federation:service">
+            <!--
+            Zero or more repetitions: Service bindings represent a way to query data
+            from this instance. Each binding can have one or more slots that define URLs or other properties.
+            For more complex properties such as query parameters use specification links to point to an
+            ExtrinsicObject that contains the required information. For federation source creation all the
+            serviceBinding slots and name will be used as properties for creating the source. Which source is
+            created will be based on the bindingType attribute which should be the factory pid of a managed service factory
+            -->
+            <rim:ServiceBinding id="urn:registry:federation:method:csw"
+                                service="urn:uuid:service:2014ca7f59ac46f495e32b4a67a51276">
+                <!--Slot defining the query url for this particular method of communicating with this instance-->
+                <rim:Slot name="cswUrl" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/address/here</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+                <!-- bindingType identifies communication message type for this binding-->
+                <rim:Slot name="bindingType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>Csw_Federated_Source</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="serviceType" slotType="xs:string">
+                    <rim:ValueList>
+                        <rim:Value>REST</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Slot name="endpointDocumentation" slotType="xs:anyURI">
+                    <rim:ValueList>
+                        <rim:Value>https://some/path/to/docs.html</rim:Value>
+                    </rim:ValueList>
+                </rim:Slot>
+
+                <rim:Name>
+                    <rim:LocalizedString value="CSW Federation Method"/>
+                </rim:Name>
+                <rim:Description>
+                    <rim:LocalizedString value="This is the CSW federation method."/>
+                </rim:Description>
+                <rim:VersionInfo versionName="2.0.2"/>
+
+                <!-- SpecificationLinks are also RegistryObjects so if needed slots can be added directly to them. If possible use an ExtrinsicObject instead.-->
+                <rim:SpecificationLink id="urn:request:parameters" serviceBinding="urn:registry:federation:method:csw" specificationObject="urn:service:params:id0"/>
+            </rim:ServiceBinding>
+        </rim:Service>
+
+        <rim:Organization id="urn:organization:id0"
+                          parent="urn:uuid:2014ca7f59ac46f495e32b4a67a51276"
+                          primaryContact="somePrimaryContact"
+                          lid="someLid"
+                          status="someStatus">
+            <rim:Name>
+                <rim:LocalizedString value="Codice"/>
+            </rim:Name>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street"/>
+            <rim:TelephoneNumber areaCode="555" number="555-5555" extension="1234"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+            <rim:Classification id="urn:classification:id0" classifiedObject="classifiedObjectId" classificationScheme="classificationScheme" classificationNode="classificationNode" nodeRepresentation="nodeRepresentation"/>
+        </rim:Organization>
+
+        <rim:Person id="urn:contact:id0" >
+            <rim:PersonName firstName="john" middleName="middleName" lastName="doe"/>
+            <rim:TelephoneNumber areaCode="111" number="111-1111" extension="1234" countryCode="country" phoneType="cell phone"/>
+            <rim:EmailAddress address="emailaddress@something.com"/>
+            <rim:Address city="Phoenix" country="USA" postalCode="85037" stateOrProvince="AZ"
+                         street="1234 Some Street" streetNumber="1234"/>
+        </rim:Person>
+
+        <!-- An organization or person associated with the 'registry.node' will be set as the overall metacards organization and contact. If there is more than one organization or person associated
+        with the registry.node the first assocaition will be used. If no association is made to the registry.node the first organization or contact found will be used-->
+        <rim:Association id="urn:assoication:1" associationType="RelatedTo" sourceObject="urn:registry:node" targetObject="urn:contact:id0"/>
+
+    </rim:RegistryObjectList>
+</rim:RegistryPackage>

--- a/catalog/registry/catalog-registry-federationadminservice/pom.xml
+++ b/catalog/registry/catalog-registry-federationadminservice/pom.xml
@@ -52,6 +52,48 @@
                     </instructions>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/catalog/registry/catalog-registry-federationadminservice/src/main/java/ddf/catalog/registry/federationadmin/service/FederationAdminException.java
+++ b/catalog/registry/catalog-registry-federationadminservice/src/main/java/ddf/catalog/registry/federationadmin/service/FederationAdminException.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package ddf.catalog.registry.federationadmin.service;
+
+public class FederationAdminException extends Exception {
+    public FederationAdminException() {
+        super();
+    }
+
+    public FederationAdminException(String message) {
+        super(message);
+    }
+
+    public FederationAdminException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/catalog/registry/catalog-registry-federationadminservice/src/main/java/ddf/catalog/registry/federationadmin/service/FederationAdminService.java
+++ b/catalog/registry/catalog-registry-federationadminservice/src/main/java/ddf/catalog/registry/federationadmin/service/FederationAdminService.java
@@ -14,42 +14,197 @@
 package ddf.catalog.registry.federationadmin.service;
 
 import java.util.List;
+import java.util.Set;
 
 import ddf.catalog.data.Metacard;
-import ddf.catalog.federation.FederationException;
-import ddf.catalog.source.IngestException;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
 
 /**
  * Service that provides the interface to get and add registry metacards
+ * <b> This code is experimental. While this interface is functional and tested, it may change or be removed in a future version of the library. </b>
  */
 public interface FederationAdminService {
 
     /**
-     * Add the given metacard to the catalog
+     * Add a registry metacard entry for the xml string provided. Converts the string to a
+     * registry metacard using the RegistryTransformer.
      *
-     * @param metacard
-     *          Metacard to be stored
-     * @throws SourceUnavailableException
-     *          If the local provider is not available.
-     * @throws IngestException
-     *          If any errors were encountered during ingest
+     * @param xml String representation of a registry package xml
+     * @return Id of the created metacard
+     * @throws FederationAdminException If the xml string is blank.
+     *                                  If an exception is thrown from the registryTransformer.
+     *                                  The CatalogFramework throws an exception trying to add the metacard.
      */
-    void addLocalEntry(Metacard metacard) throws SourceUnavailableException, IngestException;
+    String addRegistryEntry(String xml) throws FederationAdminException;
 
     /**
-     *  Get a list of registry metacards
+     * Add a registry metacard entry for the xml string provided. Converts the string to a
+     * registry metacard using the RegistryTransformer.
+     *
+     * @param xml          String representation of a registry package xml
+     * @param destinations Set of destinations to add
+     * @return Id of the created metacard
+     * @throws FederationAdminException If the xml string is blank.
+     *                                  If an exception is thrown from the registryTransformer.
+     *                                  The CatalogFramework throws an exception trying to add the metacard.
+     */
+    String addRegistryEntry(String xml, Set<String> destinations) throws FederationAdminException;
+
+    /**
+     * Add the given metacard to the registry catalog
+     *
+     * @param metacard Metacard to be stored
+     * @return Id of the created metacard
+     * @throws FederationAdminException If the metacard provided was null.
+     *                                  The CatalogFramework.create call throws IngestException or SourceUnavailableException
+     */
+    String addRegistryEntry(Metacard metacard) throws FederationAdminException;
+
+    /**
+     * Add the given metacard to the registry catalog with the provided destinations
+     *
+     * @param metacard     Metacard to be stored
+     * @param destinations Set of destinations to add
+     * @return Id of the created metacard
+     * @throws FederationAdminException If the metacard provided was null.
+     *                                  The CatalogFramework.create call throws IngestException or SourceUnavailableException
+     */
+    String addRegistryEntry(Metacard metacard, Set<String> destinations)
+            throws FederationAdminException;
+
+    /**
+     * * Deletes the registry entry from the registry catalog for each of the provided registry ids.
+     *
+     * @param registryIds The list of registry ids to be deleted.
+     * @throws FederationAdminException If the list of ids provided is empty.
+     *                                  If IngestException or Source UnavailableException was thrown by CatalogFramework.delete
+     */
+    void deleteRegistryEntriesByRegistryIds(List<String> registryIds)
+            throws FederationAdminException;
+
+    /**
+     * Deletes the registry entry from the registry catalog for each of the provided registry ids. A set of destinations is
+     * sent in the delete request
+     *
+     * @param registryIds  The list of registry ids to be deleted.
+     * @param destinations Set of destinations to add
+     * @throws FederationAdminException If the list of ids provided is empty.
+     *                                  If IngestException or Source UnavailableException was thrown by CatalogFramework.delete
+     */
+    void deleteRegistryEntriesByRegistryIds(List<String> registryIds, Set<String> destinations)
+            throws FederationAdminException;
+
+    /**
+     * * Deletes the registry entry from the registry catalog for each of the provided metacard ids.
+     *
+     * @param metacardIds The list of metacard ids to be deleted.
+     * @throws FederationAdminException If the list of ids provided is empty.
+     *                                  If IngestException or Source UnavailableException was thrown by CatalogFramework.delete
+     */
+    void deleteRegistryEntriesByMetacardIds(List<String> metacardIds)
+            throws FederationAdminException;
+
+    /**
+     * * Deletes the registry entry from the registry catalog for each of the provided metacard ids. A set of destinations is
+     * sent in the delete request
+     *
+     * @param metacardIds  The list of metacard ids to be deleted.
+     * @param destinations The set of destinations to be added
+     * @throws FederationAdminException If the list of ids provided is empty.
+     *                                  If IngestException or Source UnavailableException was thrown by CatalogFramework.delete
+     */
+    void deleteRegistryEntriesByMetacardIds(List<String> metacardIds, Set<String> destinations)
+            throws FederationAdminException;
+
+    /**
+     * * Write the provided metacard to the registry catalog. Updating the metacard currently stored.
+     *
+     * @param metacard Metacard with updates to be stored in the registry catalog
+     * @throws FederationAdminException If the provided metacard doesn't have an id.
+     *                                  If CatalogFramework.update call throws IngestException or SourceUnavailableException
+     */
+    void updateRegistryEntry(Metacard metacard) throws FederationAdminException;
+
+    /**
+     * Write the provided metacard to the registry catalog. Updating the metacard currently stored with the provided destinations.
+     *
+     * @param metacard     Metacard with updates to be stored in the registry catalog
+     * @param destinations Set of destinations to add
+     * @throws FederationAdminException If the provided metacard doesn't have an id.
+     *                                  If CatalogFramework.update call throws IngestException or SourceUnavailableException
+     */
+    void updateRegistryEntry(Metacard metacard, Set<String> destinations)
+            throws FederationAdminException;
+
+    /**
+     * Update a registry metacard for the xml string provided. The string will be converted to a registry metacard using the RegistryTransformer.
+     *
+     * @param xml String representation of a registry package xml
+     * @throws FederationAdminException If the provided metacard doesn't have an id.
+     *                                  If an exception is thrown from the RegistryTransformer
+     *                                  If CatalogFramework.update call throws IngestException or SourceUnavailableException
+     */
+    void updateRegistryEntry(String xml) throws FederationAdminException;
+
+    /**
+     * Update a registry metacard for the xml string provided. The string will be converted to a registry metacard using the RegistryTransformer.
+     * The metacard will be updated with the provided destinations
+     *
+     * @param xml          String representation of a registry package xml
+     * @param destinations Set of destinations to add
+     * @throws FederationAdminException If the provided metacard doesn't have an id.
+     *                                  If an exception is thrown from the RegistryTransformer
+     *                                  If CatalogFramework.update call throws IngestException or SourceUnavailableException
+     */
+    void updateRegistryEntry(String xml, Set<String> destinations) throws FederationAdminException;
+
+    /**
+     * Get a list of registry metacards
      *
      * @return List<Metacard>
-     * @throws UnsupportedQueryException
-     *          If runtime exception occured while performing the query.
-     *          If the query fails validation.
-     * @throws SourceUnavailableException
-     *          If the local provider is not available.
-     * @throws FederationException
-     *          If any StopProcessing Exceptions were thrown by the catalog while processing the query
+     * @throws FederationAdminException If any exception was thrown by the call to CatalogFramework.query()
      */
-    List<Metacard> getRegistryMetacards()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException;
+    List<Metacard> getRegistryMetacards() throws FederationAdminException;
+
+    /**
+     * Get a list of local registry metacards
+     *
+     * @return List<Metacard>
+     * @throws FederationAdminException If any exception was thrown by the call to CatalogFramework.query()
+     */
+    List<Metacard> getLocalRegistryMetacards() throws FederationAdminException;
+
+    /**
+     * Get a list of registry metacards with the provided registry ids. It won't run the query
+     * if the list provided is empty.
+     *
+     * @param ids List of IDs to to get metacards for
+     * @return List<Metacard>
+     * @throws FederationAdminException If empty list of registry ids is provided
+     *                                  If the list of id filters isn't created
+     *                                  If any exception was thrown by the call to CatalogFramework.query()
+     */
+    List<Metacard> getRegistryMetacardsByRegistryIds(List<String> ids)
+            throws FederationAdminException;
+
+    /**
+     * Get a list of local registry metacards with the provided registry ids. It won't run the query
+     * if the list provided is empty.
+     *
+     * @param ids List of IDs to to get metacards for
+     * @return List<Metacard>
+     * @throws FederationAdminException If empty list of registry ids is provided
+     *                                  If the list of id filters isn't created
+     *                                  If any exception was thrown by the call to CatalogFramework.query()
+     */
+    List<Metacard> getLocalRegistryMetacardsByRegistryIds(List<String> ids)
+            throws FederationAdminException;
+
+    /**
+     * Get a list of registry objects
+     *
+     * @return List<RegistryPackageType>
+     * @throws FederationAdminException If an exception is thrown trying to unmarshal the xml
+     */
+    List<RegistryPackageType> getLocalRegistryObjects() throws FederationAdminException;
 }

--- a/catalog/registry/catalog-registry-federationadminserviceimpl/src/main/java/ddf/catalog/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
+++ b/catalog/registry/catalog-registry-federationadminserviceimpl/src/main/java/ddf/catalog/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
@@ -17,20 +17,28 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 import javax.xml.datatype.DatatypeConstants;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.configuration.SystemBaseUrl;
 import org.codice.ddf.configuration.SystemInfo;
@@ -54,14 +62,20 @@ import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.federation.FederationException;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.DeleteRequest;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.DeleteRequestImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
+import ddf.catalog.operation.impl.UpdateRequestImpl;
 import ddf.catalog.registry.common.RegistryConstants;
 import ddf.catalog.registry.common.metacard.RegistryObjectMetacardType;
+import ddf.catalog.registry.federationadmin.service.FederationAdminException;
 import ddf.catalog.registry.federationadmin.service.FederationAdminService;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
@@ -94,7 +108,9 @@ public class FederationAdminServiceImpl implements FederationAdminService {
 
     private Parser parser;
 
-    private ParserConfigurator configurator;
+    private ParserConfigurator marshalConfigurator;
+
+    private ParserConfigurator unmarshalConfigurator;
 
     private FilterBuilder filterBuilder;
 
@@ -109,87 +125,290 @@ public class FederationAdminServiceImpl implements FederationAdminService {
     }
 
     @Override
-    public void addLocalEntry(Metacard metacard)
-            throws SourceUnavailableException, IngestException {
-        Subject systemSubject = security.getSystemSubject();
-        CreateRequest createRequest = new CreateRequestImpl(metacard);
-        createRequest.getProperties()
-                .put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
-
-        catalogFramework.create(createRequest);
+    public String addRegistryEntry(String xml) throws FederationAdminException {
+        Metacard metacard = getRegistryMetacardFromString(xml);
+        return addRegistryEntry(metacard);
     }
 
     @Override
-    public List<Metacard> getRegistryMetacards()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
-        List<Metacard> registryMetacards = new ArrayList<>();
+    public String addRegistryEntry(String xml, Set<String> destinations)
+            throws FederationAdminException {
+        Metacard metacard = getRegistryMetacardFromString(xml);
+        return addRegistryEntry(metacard, destinations);
+    }
+
+    @Override
+    public String addRegistryEntry(Metacard metacard) throws FederationAdminException {
+        return addRegistryEntry(metacard, null);
+    }
+
+    @Override
+    public String addRegistryEntry(Metacard metacard, Set<String> destinations)
+            throws FederationAdminException {
+        validateRegistryMetacard(metacard);
+
+        String metacardId;
+
+        Subject systemSubject = security.getSystemSubject();
+        Map<String, Serializable> properties = new HashMap<>();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+        CreateRequest createRequest = new CreateRequestImpl(Collections.singletonList(metacard),
+                properties,
+                destinations);
+
+        try {
+            CreateResponse response = catalogFramework.create(createRequest);
+            metacardId = response.getCreatedMetacards()
+                    .get(0)
+                    .getId();
+        } catch (IngestException | SourceUnavailableException e) {
+            throw new FederationAdminException("Error adding local registry entry.", e);
+        }
+
+        return metacardId;
+    }
+
+    @Override
+    public void updateRegistryEntry(String xml) throws FederationAdminException {
+        Metacard updateMetacard = getRegistryMetacardFromString(xml);
+        updateRegistryEntry(updateMetacard);
+    }
+
+    @Override
+    public void updateRegistryEntry(String xml, Set<String> destinations)
+            throws FederationAdminException {
+        Metacard updateMetacard = getRegistryMetacardFromString(xml);
+        updateRegistryEntry(updateMetacard, destinations);
+    }
+
+    @Override
+    public void updateRegistryEntry(Metacard updateMetacard) throws FederationAdminException {
+        updateRegistryEntry(updateMetacard, null);
+    }
+
+    @Override
+    public void updateRegistryEntry(Metacard updateMetacard, Set<String> destinations)
+            throws FederationAdminException {
+        validateRegistryMetacard(updateMetacard);
+
+        if (updateMetacard.getId() == null) {
+            throw new FederationAdminException(
+                    "Error updating local registry entry. Metacard Id is not set.");
+        }
+
+        Filter filter = FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.ID),
+                updateMetacard.getId());
+        List<Metacard> existingMetacards = getRegistryMetacardsByFilter(filter);
+
+        if (CollectionUtils.isEmpty(existingMetacards)) {
+            String message = "Error updating local registry entry. Registry metacard not found.";
+            LOGGER.error("{} Registry metacard ID: {}", message, updateMetacard.getId());
+            throw new FederationAdminException(message);
+        }
+
+        if (existingMetacards.size() > 1) {
+            String message =
+                    "Error updating local registry entry. Multiple registry metacards found.";
+
+            List<String> metacardIds = new ArrayList<>();
+            metacardIds.addAll(existingMetacards.stream()
+                    .map(Metacard::getId)
+                    .collect(Collectors.toList()));
+            LOGGER.error("{} Matching registry metacard ids: {}", message, metacardIds);
+
+            throw new FederationAdminException(message);
+        }
+
+        Metacard existingMetacard = existingMetacards.get(0);
+
+        for (String transientAttributeKey : RegistryObjectMetacardType.TRANSIENT_ATTRIBUTES) {
+            Attribute transientAttribute = updateMetacard.getAttribute(transientAttributeKey);
+            if (transientAttribute == null) {
+                transientAttribute = existingMetacard.getAttribute(transientAttributeKey);
+                if (transientAttribute != null) {
+                    updateMetacard.setAttribute(transientAttribute);
+                }
+            }
+        }
+
+        Subject systemSubject = security.getSystemSubject();
+        Map<String, Serializable> properties = new HashMap<>();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+
+        List<Map.Entry<Serializable, Metacard>> updateList = new ArrayList<>();
+        updateList.add(new AbstractMap.SimpleEntry<>(updateMetacard.getId(), updateMetacard));
+
+        UpdateRequest updateRequest = new UpdateRequestImpl(updateList,
+                Metacard.ID,
+                properties,
+                destinations);
+
+        try {
+            catalogFramework.update(updateRequest);
+        } catch (IngestException | SourceUnavailableException e) {
+            String message = "Error updating local registry entry.";
+            LOGGER.error("{} Metacard ID: {}", message, updateMetacard.getId());
+            throw new FederationAdminException(message, e);
+        }
+
+    }
+
+    @Override
+    public void deleteRegistryEntriesByRegistryIds(List<String> registryIds)
+            throws FederationAdminException {
+        deleteRegistryEntriesByRegistryIds(registryIds, null);
+    }
+
+    @Override
+    public void deleteRegistryEntriesByRegistryIds(List<String> registryIds,
+            Set<String> destinations) throws FederationAdminException {
+        if (CollectionUtils.isEmpty(registryIds)) {
+            throw new FederationAdminException(
+                    "An empty list of registry ids to be deleted was received. Nothing to delete.");
+        }
+
+        List<Serializable> serializableIds = new ArrayList<>(registryIds);
+        Map<String, Serializable> properties = new HashMap<>();
+        Subject systemSubject = security.getSystemSubject();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+
+        DeleteRequest deleteRequest = new DeleteRequestImpl(serializableIds,
+                RegistryObjectMetacardType.REGISTRY_ID,
+                properties,
+                destinations);
+        try {
+            catalogFramework.delete(deleteRequest);
+        } catch (IngestException | SourceUnavailableException e) {
+            String message = "Error deleting registry entries by registry id.";
+            LOGGER.error("{} Registry Ids provided: {}", message, registryIds);
+            throw new FederationAdminException(message, e);
+        }
+    }
+
+    @Override
+    public void deleteRegistryEntriesByMetacardIds(List<String> metacardIds)
+            throws FederationAdminException {
+        deleteRegistryEntriesByMetacardIds(metacardIds, null);
+    }
+
+    @Override
+    public void deleteRegistryEntriesByMetacardIds(List<String> metacardIds,
+            Set<String> destinations) throws FederationAdminException {
+        if (CollectionUtils.isEmpty(metacardIds)) {
+            throw new FederationAdminException(
+                    "An empty list of metacard ids to be deleted was received. Nothing to delete.");
+        }
+
+        List<Serializable> serializableIds = new ArrayList<>(metacardIds);
+        Map<String, Serializable> properties = new HashMap<>();
+        Subject systemSubject = security.getSystemSubject();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+
+        DeleteRequest deleteRequest = new DeleteRequestImpl(serializableIds,
+                Metacard.ID,
+                properties,
+                destinations);
+        try {
+            catalogFramework.delete(deleteRequest);
+        } catch (IngestException | SourceUnavailableException e) {
+            String message = "Error deleting registry entries by metacard ids.";
+            LOGGER.error("{} Metacard Ids provided: {}", message, metacardIds);
+            throw new FederationAdminException(message, e);
+        }
+    }
+
+    @Override
+    public List<Metacard> getRegistryMetacards() throws FederationAdminException {
 
         Filter filter =
                 FILTER_FACTORY.and(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.CONTENT_TYPE),
                         RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME),
                         FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.TAGS),
                                 RegistryConstants.REGISTRY_TAG));
-        SortBy sortBy = FILTER_FACTORY.sort(Metacard.CREATED, SortOrder.ASCENDING);
 
-        Query query = new QueryImpl(filter);
-        ((QueryImpl) query).setSortBy(sortBy);
-
-        Subject systemSubject = security.getSystemSubject();
-        QueryRequest queryRequest = new QueryRequestImpl(query);
-        queryRequest.getProperties()
-                .put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
-
-        QueryResponse queryResponse = catalogFramework.query(queryRequest);
-
-        List<Result> results = queryResponse.getResults();
-
-        for (Result result : results) {
-            Metacard metacard = result.getMetacard();
-            if (metacard != null) {
-                registryMetacards.add(metacard);
-            }
-        }
-
-        return registryMetacards;
+        return getRegistryMetacardsByFilter(filter);
     }
 
-    private Metacard getRegistryIdentityMetacard()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
-        Metacard identityMetacard = null;
+    @Override
+    public List<Metacard> getLocalRegistryMetacards() throws FederationAdminException {
 
         List<Filter> filters = new ArrayList<>();
         filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.CONTENT_TYPE),
                 RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
         filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.TAGS),
                 RegistryConstants.REGISTRY_TAG));
-        filters.add(filterBuilder.attribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE)
+        filters.add(filterBuilder.attribute(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE)
                 .is()
                 .bool(true));
 
         Filter filter = FILTER_FACTORY.and(filters);
-        SortBy sortBy = FILTER_FACTORY.sort(Metacard.CREATED, SortOrder.ASCENDING);
+        return getRegistryMetacardsByFilter(filter);
+    }
 
-        Query query = new QueryImpl(filter);
-        ((QueryImpl) query).setSortBy(sortBy);
-
-        Subject systemSubject = security.getSystemSubject();
-        QueryRequest queryRequest = new QueryRequestImpl(query);
-        queryRequest.getProperties()
-                .put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
-
-        QueryResponse queryResponse = catalogFramework.query(queryRequest);
-
-        List<Result> results = queryResponse.getResults();
-        if (CollectionUtils.isNotEmpty(results)) {
-            identityMetacard = results.get(0)
-                    .getMetacard();
-
-            if (results.size() > 1) {
-                LOGGER.error("There should only be one identity node. Found these: {}", results);
-            }
+    @Override
+    public List<Metacard> getLocalRegistryMetacardsByRegistryIds(List<String> ids)
+            throws FederationAdminException {
+        if (CollectionUtils.isEmpty(ids)) {
+            throw new FederationAdminException(
+                    "Error getting local registry metacards by registry ids. Null list of Ids provided.");
         }
 
-        return identityMetacard;
+        List<Filter> idFilters = new ArrayList<>();
+        idFilters.addAll(ids.stream()
+                .map(id -> FILTER_FACTORY.like(FILTER_FACTORY.property(RegistryObjectMetacardType.REGISTRY_ID),
+                        id))
+                .collect(Collectors.toList()));
+
+        List<Filter> filters = new ArrayList<>();
+        filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.CONTENT_TYPE),
+                RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
+        filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.TAGS),
+                RegistryConstants.REGISTRY_TAG));
+        filters.add(filterBuilder.attribute(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE)
+                .is()
+                .bool(true));
+
+        Filter filter = FILTER_FACTORY.and(filters);
+
+        filter = FILTER_FACTORY.and(filter, FILTER_FACTORY.or(idFilters));
+        return getRegistryMetacardsByFilter(filter);
+    }
+
+    @Override
+    public List<Metacard> getRegistryMetacardsByRegistryIds(List<String> ids)
+            throws FederationAdminException {
+        if (CollectionUtils.isEmpty(ids)) {
+            throw new FederationAdminException(
+                    "Error getting registry metacards by registry ids. Null list of Ids provided.");
+        }
+
+        List<Filter> idFilters = new ArrayList<>();
+        idFilters.addAll(ids.stream()
+                .map(id -> FILTER_FACTORY.like(FILTER_FACTORY.property(RegistryObjectMetacardType.REGISTRY_ID),
+                        id))
+                .collect(Collectors.toList()));
+
+        List<Filter> filters = new ArrayList<>();
+        filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.CONTENT_TYPE),
+                RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
+        filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.TAGS),
+                RegistryConstants.REGISTRY_TAG));
+
+        Filter filter = FILTER_FACTORY.and(filters);
+
+        filter = FILTER_FACTORY.and(filter, FILTER_FACTORY.or(idFilters));
+        return getRegistryMetacardsByFilter(filter);
+    }
+
+    @Override
+    public List<RegistryPackageType> getLocalRegistryObjects() throws FederationAdminException {
+        List<RegistryPackageType> registryEntries = new ArrayList<>();
+
+        for (Metacard metacard : getLocalRegistryMetacards()) {
+            String xml = metacard.getMetadata();
+            registryEntries.add(getRegistryPackageFromString(xml));
+        }
+        return registryEntries;
     }
 
     public void init() {
@@ -197,15 +416,12 @@ public class FederationAdminServiceImpl implements FederationAdminService {
             if (getRegistryIdentityMetacard() == null) {
                 createIdentityNode();
             }
-        } catch (SourceUnavailableException | UnsupportedQueryException | FederationException e) {
-            LOGGER.error("There was an error executing a query. Failed to come up properly.");
-        } catch (IngestException e) {
-            LOGGER.error(
-                    "There was an error creating the identity node. Failed to come up properly.");
+        } catch (FederationAdminException e) {
+            LOGGER.error("There was an error bringing up the Federation Admin Service.", e);
         }
     }
 
-    private void createIdentityNode() throws SourceUnavailableException, IngestException {
+    private void createIdentityNode() throws FederationAdminException {
 
         String registryPackageId = UUID.randomUUID()
                 .toString()
@@ -268,17 +484,108 @@ public class FederationAdminServiceImpl implements FederationAdminService {
                 .getIdentifiable()
                 .add(RIM_FACTORY.createIdentifiable(extrinsicObject));
 
-        Metacard identityMetacard = jaxbToMetacard(registryPackage);
+        Metacard identityMetacard = getRegistryMetacardFromRegistryPackage(registryPackage);
         if (identityMetacard != null) {
-            Attribute registryNodeAttribute =
-                    new AttributeImpl(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE, true);
-            identityMetacard.setAttribute(registryNodeAttribute);
+            identityMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE,
+                    true));
+            identityMetacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_LOCAL_NODE,
+                    true));
 
-            addLocalEntry(identityMetacard);
+            addRegistryEntry(identityMetacard);
         }
     }
 
-    private Metacard jaxbToMetacard(RegistryPackageType registryPackage) {
+    private void validateRegistryMetacard(Metacard metacard) throws FederationAdminException {
+        if (metacard == null) {
+            throw new FederationAdminException(
+                    "Error creating local registry entry. Null metacard provided.");
+        }
+
+        Attribute registryId = metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_ID);
+        if (registryId == null) {
+            throw new FederationAdminException(
+                    "ValidationError: Metacard does not have a registry id.");
+        }
+
+        Set<String> tags = metacard.getTags();
+        if (!tags.contains(RegistryConstants.REGISTRY_TAG)) {
+            throw new FederationAdminException(
+                    "ValidationError: Metacard does not have a registry tag.");
+        }
+    }
+
+    private Metacard getRegistryIdentityMetacard() throws FederationAdminException {
+        Metacard identityMetacard = null;
+
+        List<Filter> filters = new ArrayList<>();
+        filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.CONTENT_TYPE),
+                RegistryConstants.REGISTRY_NODE_METACARD_TYPE_NAME));
+        filters.add(FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.TAGS),
+                RegistryConstants.REGISTRY_TAG));
+        filters.add(filterBuilder.attribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE)
+                .is()
+                .bool(true));
+
+        Filter filter = FILTER_FACTORY.and(filters);
+
+        List<Metacard> identityMetacards = getRegistryMetacardsByFilter(filter);
+        if (CollectionUtils.isNotEmpty(identityMetacards)) {
+
+            if (identityMetacards.size() > 1) {
+                String message =
+                        "Error getting registry identity metacard. More than one result found.";
+                LOGGER.error("{} Found these: {}", message, identityMetacards);
+                throw new FederationAdminException(message);
+            }
+
+            identityMetacard = identityMetacards.get(0);
+        }
+
+        return identityMetacard;
+    }
+
+    private List<Metacard> getRegistryMetacardsByFilter(Filter filter)
+            throws FederationAdminException {
+        if (filter == null) {
+            throw new FederationAdminException(
+                    "Error getting registry metacards. Null filter provided.");
+        }
+
+        List<Metacard> registryMetacards = new ArrayList<>();
+
+        SortBy sortBy = FILTER_FACTORY.sort(Metacard.CREATED, SortOrder.ASCENDING);
+
+        Query query = new QueryImpl(filter);
+        ((QueryImpl) query).setSortBy(sortBy);
+
+        Subject systemSubject = security.getSystemSubject();
+        QueryRequest queryRequest = new QueryRequestImpl(query);
+        queryRequest.getProperties()
+                .put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+
+        try {
+            QueryResponse queryResponse = catalogFramework.query(queryRequest);
+            List<Result> results = queryResponse.getResults();
+
+            registryMetacards.addAll(results.stream()
+                    .map(Result::getMetacard)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()));
+        } catch (SourceUnavailableException | UnsupportedQueryException | FederationException e) {
+            String message = "Error querying for registry metacards.";
+            LOGGER.error("{} For Filter: {}", message, filter);
+            throw new FederationAdminException(message, e);
+        }
+
+        return registryMetacards;
+    }
+
+    private Metacard getRegistryMetacardFromRegistryPackage(RegistryPackageType registryPackage)
+            throws FederationAdminException {
+        if (registryPackage == null) {
+            throw new FederationAdminException(
+                    "Error creating metacard from registry package. Null package was received.");
+        }
         Metacard metacard;
 
         try {
@@ -286,13 +593,58 @@ public class FederationAdminServiceImpl implements FederationAdminService {
                     RIM_FACTORY.createRegistryPackage(registryPackage);
 
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            parser.marshal(configurator, jaxbRegistryObjectType, baos);
+            parser.marshal(marshalConfigurator, jaxbRegistryObjectType, baos);
             InputStream xmlInputStream = new ByteArrayInputStream(baos.toByteArray());
             metacard = registryTransformer.transform(xmlInputStream);
 
         } catch (IOException | CatalogTransformerException | ParserException e) {
-            LOGGER.error("Error creating metacard from registry package.", e);
-            metacard = null;
+            String message = "Error creating metacard from registry package.";
+            LOGGER.error("{} Registry id: {}", message, registryPackage.getId());
+            throw new FederationAdminException(message, e);
+        }
+
+        return metacard;
+    }
+
+    private RegistryPackageType getRegistryPackageFromString(String xml)
+            throws FederationAdminException {
+        if (StringUtils.isBlank(xml)) {
+            throw new FederationAdminException(
+                    "Error unmarshalling xml string to RegistryPackage. Empty string was provided.");
+        }
+
+        RegistryPackageType registryPackage = null;
+
+        try {
+            JAXBElement<RegistryPackageType> jaxbRegistryPackage = parser.unmarshal(
+                    unmarshalConfigurator,
+                    JAXBElement.class,
+                    IOUtils.toInputStream(xml));
+            if (jaxbRegistryPackage != null && jaxbRegistryPackage.getValue() != null) {
+                registryPackage = jaxbRegistryPackage.getValue();
+            }
+        } catch (ParserException e) {
+            String message = "Error getting local registry objects. Couldn't unmarshal the string.";
+            LOGGER.error("{} String: {}", message, xml);
+            throw new FederationAdminException(message, e);
+        }
+
+        return registryPackage;
+    }
+
+    private Metacard getRegistryMetacardFromString(String xml) throws FederationAdminException {
+        if (StringUtils.isBlank(xml)) {
+            throw new FederationAdminException(
+                    "Error unmarshalling string to Metacard. Empty string was provided.");
+        }
+        Metacard metacard;
+
+        try {
+            metacard = registryTransformer.transform(IOUtils.toInputStream(xml));
+        } catch (IOException | CatalogTransformerException e) {
+            String message = "Error transforming xml string to metacard.";
+            LOGGER.error("{}. XML: {}", message, xml);
+            throw new FederationAdminException(message);
         }
 
         return metacard;
@@ -317,14 +669,21 @@ public class FederationAdminServiceImpl implements FederationAdminService {
     }
 
     public void setParser(Parser parser) {
-        this.configurator =
-                parser.configureParser(Arrays.asList(RegistryObjectType.class.getPackage()
-                                .getName(),
-                        net.opengis.ogc.ObjectFactory.class.getPackage()
-                                .getName(),
-                        net.opengis.gml.v_3_1_1.ObjectFactory.class.getPackage()
-                                .getName()), FederationAdminServiceImpl.class.getClassLoader());
-        this.configurator.addProperty(Marshaller.JAXB_FRAGMENT, true);
+        List<String> contextPath = Arrays.asList(RegistryObjectType.class.getPackage()
+                        .getName(),
+                net.opengis.ogc.ObjectFactory.class.getPackage()
+                        .getName(),
+                net.opengis.gml.v_3_1_1.ObjectFactory.class.getPackage()
+                        .getName());
+
+        ClassLoader classLoader = this.getClass()
+                .getClassLoader();
+
+        this.marshalConfigurator = parser.configureParser(contextPath, classLoader);
+        this.marshalConfigurator.addProperty(Marshaller.JAXB_FRAGMENT, true);
+
+        this.unmarshalConfigurator = parser.configureParser(contextPath, classLoader);
+
         this.parser = parser;
     }
 

--- a/catalog/registry/catalog-registry-federationadminserviceimpl/src/test/java/ddf/catalog/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
+++ b/catalog/registry/catalog-registry-federationadminserviceimpl/src/test/java/ddf/catalog/registry/federationadmin/service/impl/FederationAdminServiceImplTest.java
@@ -14,20 +14,33 @@
 package ddf.catalog.registry.federationadmin.service.impl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.xml.bind.JAXBElement;
 
 import org.codice.ddf.configuration.SystemInfo;
 import org.codice.ddf.parser.Parser;
@@ -52,29 +65,41 @@ import ddf.catalog.data.Result;
 import ddf.catalog.data.impl.AttributeImpl;
 import ddf.catalog.data.impl.MetacardImpl;
 import ddf.catalog.data.impl.ResultImpl;
+import ddf.catalog.federation.FederationException;
 import ddf.catalog.filter.AttributeBuilder;
 import ddf.catalog.filter.ExpressionBuilder;
 import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.CreateRequest;
+import ddf.catalog.operation.CreateResponse;
+import ddf.catalog.operation.DeleteRequest;
 import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
+import ddf.catalog.operation.UpdateRequest;
+import ddf.catalog.operation.impl.CreateRequestImpl;
+import ddf.catalog.operation.impl.CreateResponseImpl;
 import ddf.catalog.operation.impl.QueryImpl;
 import ddf.catalog.operation.impl.QueryRequestImpl;
 import ddf.catalog.operation.impl.QueryResponseImpl;
 import ddf.catalog.registry.common.RegistryConstants;
 import ddf.catalog.registry.common.metacard.RegistryObjectMetacardType;
+import ddf.catalog.registry.federationadmin.service.FederationAdminException;
 import ddf.catalog.registry.transformer.RegistryTransformer;
 import ddf.catalog.source.IngestException;
 import ddf.catalog.source.SourceUnavailableException;
 import ddf.catalog.source.UnsupportedQueryException;
+import ddf.catalog.transform.CatalogTransformerException;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ObjectFactory;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
 
 @RunWith(MockitoJUnitRunner.class)
 public class FederationAdminServiceImplTest {
 
     private static final FilterFactory FILTER_FACTORY = new FilterFactoryImpl();
+
+    private static final ObjectFactory RIM_FACTORY = new ObjectFactory();
 
     private static final String TEST_SITE_NAME = "Slate Rock and Gravel Company";
 
@@ -138,7 +163,7 @@ public class FederationAdminServiceImplTest {
 
         fasi.init();
 
-        verify(fasi).addLocalEntry(metacard);
+        verify(fasi).addRegistryEntry(metacard);
     }
 
     @Test
@@ -153,7 +178,7 @@ public class FederationAdminServiceImplTest {
 
         fasi.init();
 
-        verify(fasi).addLocalEntry(addThisMetacard);
+        verify(fasi).addRegistryEntry(addThisMetacard);
     }
 
     @Test
@@ -169,7 +194,7 @@ public class FederationAdminServiceImplTest {
 
         fasi.init();
 
-        verify(fasi).addLocalEntry(addThisMetacard);
+        verify(fasi).addRegistryEntry(addThisMetacard);
     }
 
     @Test
@@ -188,7 +213,7 @@ public class FederationAdminServiceImplTest {
 
         fasi.init();
 
-        verify(fasi, never()).addLocalEntry(addThisMetacard);
+        verify(fasi, never()).addRegistryEntry(addThisMetacard);
     }
 
     @Test
@@ -209,7 +234,7 @@ public class FederationAdminServiceImplTest {
 
         fasi.init();
 
-        verify(fasi, never()).addLocalEntry(addThisMetacard);
+        verify(fasi, never()).addRegistryEntry(addThisMetacard);
     }
 
     @Test
@@ -219,7 +244,7 @@ public class FederationAdminServiceImplTest {
                 .query(any(QueryRequest.class));
 
         fasi.init();
-        verify(fasi, never()).addLocalEntry(any(Metacard.class));
+        verify(fasi, never()).addRegistryEntry(any(Metacard.class));
     }
 
     @Test
@@ -234,7 +259,7 @@ public class FederationAdminServiceImplTest {
                 .create(any(CreateRequest.class));
 
         fasi.init();
-        verify(fasi).addLocalEntry(any(Metacard.class));
+        verify(fasi).addRegistryEntry(any(Metacard.class));
     }
 
     @Test
@@ -247,11 +272,734 @@ public class FederationAdminServiceImplTest {
                 .marshal(any(ParserConfigurator.class), any(Object.class), any(OutputStream.class));
 
         fasi.init();
-        verify(fasi, never()).addLocalEntry(any(Metacard.class));
+        verify(fasi, never()).addRegistryEntry(any(Metacard.class));
     }
 
     @Test
-    public void testGetRegistryMetacard() throws Exception {
+    public void testAddRegistryEntry() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard createdMetacard = metacard;
+        createdMetacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        Subject systemSubject = security.getSystemSubject();
+        Map<String, Serializable> properties = new HashMap<>();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+        CreateRequest request = new CreateRequestImpl(Collections.singletonList(metacard),
+                properties,
+                destinations);
+        CreateResponse response = new CreateResponseImpl(request,
+                null,
+                Collections.singletonList(createdMetacard));
+
+        when(catalogFramework.create(any(CreateRequest.class))).thenReturn(response);
+
+        String createdMetacardId = fasi.addRegistryEntry(metacard, destinations);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(catalogFramework).create(any(CreateRequest.class));
+    }
+
+    @Test
+    public void testAddRegistryEntryWithNullDestinations() throws Exception {
+        String registryId = "registryId";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard createdMetacard = metacard;
+        createdMetacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+
+        Set<String> destinations = null;
+
+        Subject systemSubject = security.getSystemSubject();
+        Map<String, Serializable> properties = new HashMap<>();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+        CreateRequest request = new CreateRequestImpl(Collections.singletonList(metacard),
+                properties,
+                destinations);
+        CreateResponse response = new CreateResponseImpl(request,
+                null,
+                Collections.singletonList(createdMetacard));
+
+        when(catalogFramework.create(any(CreateRequest.class))).thenReturn(response);
+
+        String createdMetacardId = fasi.addRegistryEntry(metacard, destinations);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(catalogFramework).create(any(CreateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testAddRegistryEntryWithNullMetacard() throws Exception {
+        String destination = "someDestination";
+        Metacard metacard = null;
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        fasi.addRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework, never()).create(any(CreateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testAddRegistryEntryWithInvalidMetacardNoRegistryId() throws Exception {
+        String destination = "someDestination";
+        Metacard metacard = getTestMetacard();
+
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        fasi.addRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework, never()).create(any(CreateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testAddRegistryEntryWithInvalidMetacardNoRegistryTag() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        fasi.addRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework, never()).create(any(CreateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testAddRegistryEntryWithIngestException() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        when(catalogFramework.create(any(CreateRequest.class))).thenThrow(IngestException.class);
+
+        fasi.addRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework, never()).create(any(CreateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testAddRegistryEntryWithSourceUnavailableException() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        when(catalogFramework.create(any(CreateRequest.class))).thenThrow(SourceUnavailableException.class);
+
+        fasi.addRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework, never()).create(any(CreateRequest.class));
+    }
+
+    @Test
+    public void testAddRegistryEntryMetacard() throws Exception {
+        String registryId = "registryId";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard createdMetacard = metacard;
+        createdMetacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+
+        Subject systemSubject = security.getSystemSubject();
+        Map<String, Serializable> properties = new HashMap<>();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+        CreateRequest request = new CreateRequestImpl(Collections.singletonList(metacard),
+                properties,
+                null);
+        CreateResponse response = new CreateResponseImpl(request,
+                null,
+                Collections.singletonList(createdMetacard));
+
+        when(catalogFramework.create(any(CreateRequest.class))).thenReturn(response);
+
+        String createdMetacardId = fasi.addRegistryEntry(metacard);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(catalogFramework).create(any(CreateRequest.class));
+    }
+
+    @Test
+    public void testAddRegistryEntryStringWithDestinations() throws Exception {
+        String xml = "someValidStringVersionOfXml";
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard createdMetacard = metacard;
+        createdMetacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        Subject systemSubject = security.getSystemSubject();
+        Map<String, Serializable> properties = new HashMap<>();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+        CreateRequest request = new CreateRequestImpl(Collections.singletonList(metacard),
+                properties,
+                destinations);
+        CreateResponse response = new CreateResponseImpl(request,
+                null,
+                Collections.singletonList(createdMetacard));
+
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(catalogFramework.create(any(CreateRequest.class))).thenReturn(response);
+
+        String createdMetacardId = fasi.addRegistryEntry(xml, destinations);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(catalogFramework).create(any(CreateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testAddRegistryEntryStringWithTransformerException() throws Exception {
+        String xml = "someValidStringVersionOfXml";
+        String registryId = "registryId";
+        String destination = "someDestination";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        when(registryTransformer.transform(any(InputStream.class))).thenThrow(
+                CatalogTransformerException.class);
+
+        fasi.addRegistryEntry(xml, destinations);
+
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(catalogFramework, never()).create(any(CreateRequest.class));
+    }
+
+    @Test
+    public void testAddRegistryEntryString() throws Exception {
+        String xml = "someValidStringVersionOfXml";
+        String registryId = "registryId";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard createdMetacard = metacard;
+        createdMetacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+
+        Subject systemSubject = security.getSystemSubject();
+        Map<String, Serializable> properties = new HashMap<>();
+        properties.put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
+        CreateRequest request = new CreateRequestImpl(Collections.singletonList(metacard),
+                properties,
+                null);
+        CreateResponse response = new CreateResponseImpl(request,
+                null,
+                Collections.singletonList(createdMetacard));
+
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(catalogFramework.create(any(CreateRequest.class))).thenReturn(response);
+
+        String createdMetacardId = fasi.addRegistryEntry(xml);
+
+        assertThat(createdMetacardId, is(equalTo(metacardId)));
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(catalogFramework).create(any(CreateRequest.class));
+    }
+
+    @Test
+    public void testUpdateRegistryEntry() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard);
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        fasi.updateRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework).update(any(UpdateRequest.class));
+    }
+
+    @Test
+    public void testUpdateRegistryEntryWithNullDestinations() throws Exception {
+        String registryId = "registryId";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        Set<String> destinations = null;
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard);
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        fasi.updateRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework).update(any(UpdateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateRegistryEntryWithNoMetacardId() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        fasi.updateRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework, never()).query(any(QueryRequest.class));
+        verify(catalogFramework, never()).update(any(UpdateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateRegistryEntryWithNoExistingMetacard() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest());
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        fasi.updateRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework, never()).update(any(UpdateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateRegistryEntryWithMultipleMetacardMatches() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard,
+                getTestMetacard());
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        fasi.updateRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework, never()).update(any(UpdateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateRegistryEntryWithIngestException() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard);
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+        when(catalogFramework.update(any(UpdateRequest.class))).thenThrow(IngestException.class);
+
+        fasi.updateRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework).update(any(UpdateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateRegistryEntryWithSourceUnavailableException() throws Exception {
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard);
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+        when(catalogFramework.update(any(UpdateRequest.class))).thenThrow(SourceUnavailableException.class);
+
+        fasi.updateRegistryEntry(metacard, destinations);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework).update(any(UpdateRequest.class));
+    }
+
+    @Test
+    public void testUpdateRegistryEntryMetacard() throws Exception {
+        String registryId = "registryId";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard);
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        fasi.updateRegistryEntry(metacard);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework).update(any(UpdateRequest.class));
+    }
+
+    @Test
+    public void testUpdateRegistryEntryStringWithDestinations() throws Exception {
+        String xml = "someValidStringXml";
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard);
+
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        fasi.updateRegistryEntry(xml, destinations);
+
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework).update(any(UpdateRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testUpdateRegistryEntryStringWithTransformerException() throws Exception {
+        String xml = "someValidStringXml";
+        String registryId = "registryId";
+        String destination = "someDestination";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard);
+
+        when(registryTransformer.transform(any(InputStream.class))).thenThrow(
+                CatalogTransformerException.class);
+
+        fasi.updateRegistryEntry(xml, destinations);
+
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(catalogFramework, never()).query(any(QueryRequest.class));
+        verify(catalogFramework, never()).update(any(UpdateRequest.class));
+    }
+
+    @Test
+    public void testUpdateRegistryEntryString() throws Exception {
+        String xml = "someValidStringXml";
+        String registryId = "registryId";
+        String metacardId = "someMetacardId";
+        Metacard metacard = getTestMetacard();
+        metacard.setAttribute(new AttributeImpl(Metacard.ID, metacardId));
+        metacard.setAttribute(new AttributeImpl(RegistryObjectMetacardType.REGISTRY_ID,
+                registryId));
+        metacard.setAttribute(new AttributeImpl(Metacard.TAGS,
+                Collections.singletonList(RegistryConstants.REGISTRY_TAG)));
+
+        Metacard existingMetacard = getTestMetacard();
+
+        QueryResponse response = getPopulatedTestQueryResponse(getTestQueryRequest(),
+                existingMetacard);
+
+        when(registryTransformer.transform(any(InputStream.class))).thenReturn(metacard);
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        fasi.updateRegistryEntry(xml);
+
+        verify(registryTransformer).transform(any(InputStream.class));
+        verify(catalogFramework).query(any(QueryRequest.class));
+        verify(catalogFramework).update(any(UpdateRequest.class));
+    }
+
+    @Test
+    public void testDeleteRegistryEntriesByRegistryIds() throws Exception {
+        String firstId = "firstRegistyId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstId);
+
+        String destination = "destination";
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        fasi.deleteRegistryEntriesByRegistryIds(ids, destinations);
+
+        verify(catalogFramework).delete(any(DeleteRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteRegistryEntriesByRegistryIdsWithEmptyList() throws Exception {
+        List<String> ids = new ArrayList<>();
+
+        String destination = "destination";
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        fasi.deleteRegistryEntriesByRegistryIds(ids, destinations);
+
+        verify(catalogFramework, never()).delete(any(DeleteRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteRegistryEntriesByRegistryIdsWithSourceUnavailableException()
+            throws Exception {
+        String firstId = "firstRegistyId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstId);
+
+        String destination = "destination";
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        when(catalogFramework.delete(any(DeleteRequest.class))).thenThrow(SourceUnavailableException.class);
+        fasi.deleteRegistryEntriesByRegistryIds(ids, destinations);
+
+        verify(catalogFramework).delete(any(DeleteRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteRegistryEntriesByRegistryIdsWithIngestException() throws Exception {
+        String firstId = "firstRegistyId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstId);
+
+        String destination = "destination";
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        when(catalogFramework.delete(any(DeleteRequest.class))).thenThrow(IngestException.class);
+        fasi.deleteRegistryEntriesByRegistryIds(ids, destinations);
+
+        verify(catalogFramework).delete(any(DeleteRequest.class));
+    }
+
+    @Test
+    public void testDeleteRegistryEntriesByRegistryIdsNoDestinations() throws Exception {
+        String firstId = "firstRegistyId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstId);
+
+        fasi.deleteRegistryEntriesByRegistryIds(ids);
+
+        verify(catalogFramework).delete(any(DeleteRequest.class));
+    }
+
+    @Test
+    public void testDeleteRegistryEntriesByMetacardIds() throws Exception {
+        String firstId = "firstRegistyId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstId);
+
+        String destination = "destination";
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        fasi.deleteRegistryEntriesByMetacardIds(ids, destinations);
+
+        verify(catalogFramework).delete(any(DeleteRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteRegistryEntriesByMetacardIdsWithEmptyList() throws Exception {
+        List<String> ids = new ArrayList<>();
+
+        String destination = "destination";
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        fasi.deleteRegistryEntriesByMetacardIds(ids, destinations);
+
+        verify(catalogFramework, never()).delete(any(DeleteRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteRegistryEntriesByMetacardIdsWithSourceUnavailableException()
+            throws Exception {
+        String firstId = "firstRegistyId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstId);
+
+        String destination = "destination";
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        when(catalogFramework.delete(any(DeleteRequest.class))).thenThrow(SourceUnavailableException.class);
+        fasi.deleteRegistryEntriesByMetacardIds(ids, destinations);
+
+        verify(catalogFramework).delete(any(DeleteRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testDeleteRegistryEntriesByMetacardIdsWithIngestException() throws Exception {
+        String firstId = "firstRegistyId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstId);
+
+        String destination = "destination";
+        Set<String> destinations = new HashSet<>();
+        destinations.add(destination);
+
+        when(catalogFramework.delete(any(DeleteRequest.class))).thenThrow(IngestException.class);
+        fasi.deleteRegistryEntriesByMetacardIds(ids, destinations);
+
+        verify(catalogFramework).delete(any(DeleteRequest.class));
+    }
+
+    @Test
+    public void testDeleteRegistryEntriesByMetacardIdsNoDestinations() throws Exception {
+        String firstId = "firstRegistyId";
+        List<String> ids = new ArrayList<>();
+        ids.add(firstId);
+
+        fasi.deleteRegistryEntriesByRegistryIds(ids);
+
+        verify(catalogFramework).delete(any(DeleteRequest.class));
+    }
+
+    @Test
+    public void testGetRegistryMetacards() throws Exception {
         Metacard addThisMetacard = getTestMetacard();
         Metacard findThisMetacard = getTestMetacard();
         Attribute regNodeStatus =
@@ -272,20 +1020,8 @@ public class FederationAdminServiceImplTest {
         assertThat(metacards, hasSize(2));
     }
 
-    @Test(expected = IngestException.class)
-    public void testAddLocalEntryCreateException() throws Exception {
-        Metacard metacard = getTestMetacard();
-
-        when(security.getSystemSubject()).thenReturn(subject);
-        doThrow(IngestException.class).when(catalogFramework)
-                .create(any(CreateRequest.class));
-
-        fasi.addLocalEntry(metacard);
-        verify(fasi).addLocalEntry(any(Metacard.class));
-    }
-
-    @Test(expected = UnsupportedQueryException.class)
-    public void testGetRegistryMetacardsUnsupportedQueryException() throws Exception {
+    @Test(expected = FederationAdminException.class)
+    public void testGetRegistryMetacardsWithUnsupportedQueryException() throws Exception {
         when(security.getSystemSubject()).thenReturn(subject);
         doThrow(UnsupportedQueryException.class).when(catalogFramework)
                 .query(any(QueryRequest.class));
@@ -294,10 +1030,326 @@ public class FederationAdminServiceImplTest {
         verify(fasi).getRegistryMetacards();
     }
 
-    private Metacard getTestMetacard() {
-        Metacard metacard = new MetacardImpl(new RegistryObjectMetacardType());
+    @Test(expected = FederationAdminException.class)
+    public void testGetRegistryMetacardsWithSourceUnavailableException() throws Exception {
+        when(security.getSystemSubject()).thenReturn(subject);
+        doThrow(SourceUnavailableException.class).when(catalogFramework)
+                .query(any(QueryRequest.class));
 
-        return metacard;
+        fasi.getRegistryMetacards();
+        verify(fasi).getRegistryMetacards();
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetRegistryMetacardsWithFederationException() throws Exception {
+        when(security.getSystemSubject()).thenReturn(subject);
+        doThrow(FederationException.class).when(catalogFramework)
+                .query(any(QueryRequest.class));
+
+        fasi.getRegistryMetacards();
+        verify(fasi).getRegistryMetacards();
+    }
+
+    @Test
+    public void testGetLocalRegistryMetacards() throws Exception {
+        QueryRequest request = getTestQueryRequest();
+        QueryResponse response = getPopulatedTestQueryResponse(request,
+                getTestMetacard(),
+                getTestMetacard());
+
+        when(security.getSystemSubject()).thenReturn(subject);
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        List<Metacard> metacards = fasi.getLocalRegistryMetacards();
+
+        verify(fasi).getLocalRegistryMetacards();
+        verify(catalogFramework).query(any(QueryRequest.class));
+        assertThat(metacards, hasSize(2));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryMetacardsWithUnsupportedQueryException() throws Exception {
+        when(security.getSystemSubject()).thenReturn(subject);
+        doThrow(UnsupportedQueryException.class).when(catalogFramework)
+                .query(any(QueryRequest.class));
+
+        fasi.getLocalRegistryMetacards();
+        verify(fasi).getRegistryMetacards();
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryMetacardsWithSourceUnavailableException() throws Exception {
+        when(security.getSystemSubject()).thenReturn(subject);
+        doThrow(SourceUnavailableException.class).when(catalogFramework)
+                .query(any(QueryRequest.class));
+
+        fasi.getLocalRegistryMetacards();
+        verify(fasi).getRegistryMetacards();
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryMetacardsWithFederationException() throws Exception {
+        when(security.getSystemSubject()).thenReturn(subject);
+        doThrow(FederationException.class).when(catalogFramework)
+                .query(any(QueryRequest.class));
+
+        fasi.getLocalRegistryMetacards();
+        verify(fasi).getRegistryMetacards();
+    }
+
+    @Test
+    public void testGetRegistryMetacardsByRegistryIds() throws Exception {
+        QueryRequest request = getTestQueryRequest();
+        QueryResponse response = getPopulatedTestQueryResponse(request,
+                getTestMetacard(),
+                getTestMetacard(),
+                getTestMetacard());
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        List<String> ids = new ArrayList<>();
+        ids.add("someMadeUpId");
+        ids.add("anotherOne");
+        ids.add("oneMore");
+
+        List<Metacard> metacards = fasi.getRegistryMetacardsByRegistryIds(ids);
+
+        assertThat(metacards, hasSize(3));
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetRegistryMetacardsByRegistryIdsWithEmptyList() throws Exception {
+        List<String> ids = new ArrayList<>();
+
+        fasi.getRegistryMetacardsByRegistryIds(ids);
+
+        verify(catalogFramework, never()).query(any(QueryRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetRegistryMetacardsByRegistryIdsWithSourceUnavailableException()
+            throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("someMadeUpId");
+        ids.add("anotherOne");
+        ids.add("oneMore");
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenThrow(SourceUnavailableException.class);
+
+        fasi.getRegistryMetacardsByRegistryIds(ids);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetRegistryMetacardsByRegistryIdsWithUnsupportedQueryException()
+            throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("someMadeUpId");
+        ids.add("anotherOne");
+        ids.add("oneMore");
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenThrow(UnsupportedQueryException.class);
+
+        fasi.getRegistryMetacardsByRegistryIds(ids);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetRegistryMetacardsByRegistryIdsWithFederationException() throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("someMadeUpId");
+        ids.add("anotherOne");
+        ids.add("oneMore");
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenThrow(FederationException.class);
+
+        fasi.getRegistryMetacardsByRegistryIds(ids);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+    }
+
+    @Test
+    public void testGetLocalRegistryMetacardsByRegistryIds() throws Exception {
+        QueryRequest request = getTestQueryRequest();
+        QueryResponse response = getPopulatedTestQueryResponse(request,
+                getTestMetacard(),
+                getTestMetacard(),
+                getTestMetacard());
+        when(catalogFramework.query(any(QueryRequest.class))).thenReturn(response);
+
+        List<String> ids = new ArrayList<>();
+        ids.add("someMadeUpId");
+        ids.add("anotherOne");
+        ids.add("oneMore");
+
+        List<Metacard> metacards = fasi.getLocalRegistryMetacardsByRegistryIds(ids);
+
+        assertThat(metacards, hasSize(3));
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryMetacardsByRegistryIdsWithEmptyList() throws Exception {
+        List<String> ids = new ArrayList<>();
+
+        fasi.getLocalRegistryMetacardsByRegistryIds(ids);
+
+        verify(catalogFramework, never()).query(any(QueryRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryMetacardsByRegistryIdsWithSourceUnavailableException()
+            throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("someMadeUpId");
+        ids.add("anotherOne");
+        ids.add("oneMore");
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenThrow(SourceUnavailableException.class);
+
+        fasi.getLocalRegistryMetacardsByRegistryIds(ids);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryMetacardsByRegistryIdsWithUnsupportedQueryException()
+            throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("someMadeUpId");
+        ids.add("anotherOne");
+        ids.add("oneMore");
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenThrow(UnsupportedQueryException.class);
+
+        fasi.getLocalRegistryMetacardsByRegistryIds(ids);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryMetacardsByRegistryIdsWithFederationException()
+            throws Exception {
+        List<String> ids = new ArrayList<>();
+        ids.add("someMadeUpId");
+        ids.add("anotherOne");
+        ids.add("oneMore");
+
+        when(catalogFramework.query(any(QueryRequest.class))).thenThrow(FederationException.class);
+
+        fasi.getLocalRegistryMetacardsByRegistryIds(ids);
+
+        verify(catalogFramework).query(any(QueryRequest.class));
+    }
+
+    @Test
+    public void testGetLocalRegistryObjects() throws Exception {
+        Metacard localMetacardOne = getTestMetacard();
+        localMetacardOne.setAttribute(new AttributeImpl(Metacard.METADATA, "xmlString"));
+
+        Metacard localMetacardTwo = getTestMetacard();
+        localMetacardTwo.setAttribute(new AttributeImpl(Metacard.METADATA, "anotherXmlString"));
+
+        List<Metacard> localMetacards = new ArrayList<>();
+        localMetacards.add(localMetacardOne);
+        localMetacards.add(localMetacardTwo);
+
+        doReturn(localMetacards).when(fasi)
+                .getLocalRegistryMetacards();
+
+        JAXBElement<RegistryPackageType> jaxbRegistryPackage = RIM_FACTORY.createRegistryPackage(
+                getTestRegistryPackage());
+        when(parser.unmarshal(any(ParserConfigurator.class),
+                eq(JAXBElement.class),
+                any(InputStream.class))).thenReturn(jaxbRegistryPackage);
+
+        List<RegistryPackageType> packages = fasi.getLocalRegistryObjects();
+
+        assertThat(packages, hasSize(2));
+
+        verify(fasi).getLocalRegistryMetacards();
+        verify(parser, times(2)).unmarshal(any(ParserConfigurator.class),
+                eq(JAXBElement.class),
+                any(InputStream.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryObjectsWithEmptyMetadata() throws Exception {
+        Metacard localMetacardOne = getTestMetacard();
+        localMetacardOne.setAttribute(new AttributeImpl(Metacard.METADATA, ""));
+
+        List<Metacard> localMetacards = new ArrayList<>();
+        localMetacards.add(localMetacardOne);
+
+        doReturn(localMetacards).when(fasi)
+                .getLocalRegistryMetacards();
+
+        fasi.getLocalRegistryObjects();
+
+        verify(fasi).getLocalRegistryMetacards();
+        verify(parser, never()).unmarshal(any(ParserConfigurator.class),
+                eq(JAXBElement.class),
+                any(InputStream.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryObjectsWithQueryException() throws Exception {
+        doThrow(FederationAdminException.class).when(fasi)
+                .getLocalRegistryMetacards();
+
+        fasi.getLocalRegistryObjects();
+
+        verify(fasi).getLocalRegistryMetacards();
+        verify(parser, never()).unmarshal(any(ParserConfigurator.class),
+                eq(JAXBElement.class),
+                any(InputStream.class));
+    }
+
+    @Test(expected = FederationAdminException.class)
+    public void testGetLocalRegistryObjectsWithParserException() throws Exception {
+        Metacard localMetacardOne = getTestMetacard();
+        localMetacardOne.setAttribute(new AttributeImpl(Metacard.METADATA, "someXmlMetadata"));
+
+        List<Metacard> localMetacards = new ArrayList<>();
+        localMetacards.add(localMetacardOne);
+
+        doReturn(localMetacards).when(fasi)
+                .getLocalRegistryMetacards();
+        when(parser.unmarshal(any(ParserConfigurator.class),
+                eq(JAXBElement.class),
+                any(InputStream.class))).thenThrow(ParserException.class);
+
+        fasi.getLocalRegistryObjects();
+
+        verify(fasi).getLocalRegistryMetacards();
+        verify(parser).unmarshal(any(ParserConfigurator.class),
+                eq(JAXBElement.class),
+                any(InputStream.class));
+    }
+
+    @Test
+    public void testGetLocalRegistryObjectsWithNoRegistryEntries() throws Exception {
+        List<Metacard> localMetacards = new ArrayList<>();
+
+        doReturn(localMetacards).when(fasi)
+                .getLocalRegistryMetacards();
+
+        List<RegistryPackageType> packages = fasi.getLocalRegistryObjects();
+
+        assertThat(packages, empty());
+
+        verify(fasi).getLocalRegistryMetacards();
+        verify(parser, never()).unmarshal(any(ParserConfigurator.class),
+                eq(JAXBElement.class),
+                any(InputStream.class));
+    }
+
+    private Metacard getTestMetacard() {
+        return new MetacardImpl(new RegistryObjectMetacardType());
     }
 
     private Filter getTestFilter() {
@@ -333,6 +1385,10 @@ public class FederationAdminServiceImplTest {
 
     private QueryResponse getTestQueryResponse(QueryRequest request, List<Result> results) {
         return new QueryResponseImpl(request, results, results.size());
+    }
+
+    private RegistryPackageType getTestRegistryPackage() {
+        return RIM_FACTORY.createRegistryPackageType();
     }
 
 }

--- a/catalog/registry/catalog-registry-identificationplugin/pom.xml
+++ b/catalog/registry/catalog-registry-identificationplugin/pom.xml
@@ -76,7 +76,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Embed-Dependency>
                             catalog-registry-common,
-                            catalog-core-api-impl
+                            catalog-core-api-impl;scope=!test
                         </Embed-Dependency>
                         <Import-Package>
                             !org.codice.ddf.platform.util,

--- a/catalog/registry/catalog-registry-identificationplugin/src/main/java/ddf/catalog/registry/identification/IdentificationPlugin.java
+++ b/catalog/registry/catalog-registry-identificationplugin/src/main/java/ddf/catalog/registry/identification/IdentificationPlugin.java
@@ -34,7 +34,6 @@ import com.google.common.base.Charsets;
 
 import ddf.catalog.data.Metacard;
 import ddf.catalog.data.impl.AttributeImpl;
-import ddf.catalog.federation.FederationException;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteRequest;
@@ -47,9 +46,8 @@ import ddf.catalog.plugin.PreIngestPlugin;
 import ddf.catalog.plugin.StopProcessingException;
 import ddf.catalog.registry.common.RegistryConstants;
 import ddf.catalog.registry.common.metacard.RegistryObjectMetacardType;
+import ddf.catalog.registry.federationadmin.service.FederationAdminException;
 import ddf.catalog.registry.federationadmin.service.FederationAdminService;
-import ddf.catalog.source.SourceUnavailableException;
-import ddf.catalog.source.UnsupportedQueryException;
 import ddf.catalog.util.impl.Requests;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExternalIdentifierType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
@@ -228,8 +226,7 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
                 .toString();
     }
 
-    public void init()
-            throws UnsupportedQueryException, SourceUnavailableException, FederationException {
+    public void init() throws FederationAdminException {
 
         List<Metacard> registryMetacards = federationAdmin.getRegistryMetacards();
 

--- a/catalog/registry/pom.xml
+++ b/catalog/registry/pom.xml
@@ -63,6 +63,16 @@
             </dependency>
             <dependency>
                 <groupId>ddf.catalog.registry</groupId>
+                <artifactId>catalog-registry-federationadminimpl</artifactId>
+                <version>2.9.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>ddf.catalog.registry</groupId>
+                <artifactId>catalog-registry-federationadminapi</artifactId>
+                <version>2.9.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>ddf.catalog.registry</groupId>
                 <artifactId>catalog-registry-identificationplugin</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -131,6 +141,8 @@
         <module>catalog-registry-identificationplugin</module>
         <module>catalog-registry-api</module>
         <module>catalog-registry-api-impl</module>
+        <module>catalog-registry-federationadminapi</module>
+        <module>catalog-registry-federationadminimpl</module>
         <module>catalog-registry-federationadminservice</module>
         <module>catalog-registry-federationadminserviceimpl</module>
         <module>registry-app</module>

--- a/catalog/registry/registry-app/pom.xml
+++ b/catalog/registry/registry-app/pom.xml
@@ -53,6 +53,14 @@
         </dependency>
         <dependency>
             <groupId>ddf.catalog.registry</groupId>
+            <artifactId>catalog-registry-federationadminapi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.registry</groupId>
+            <artifactId>catalog-registry-federationadminimpl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.registry</groupId>
             <artifactId>catalog-registry-identificationplugin</artifactId>
         </dependency>
         <dependency>

--- a/catalog/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/registry/registry-app/src/main/resources/features.xml
@@ -39,6 +39,8 @@
         <bundle>mvn:ddf.catalog.registry/catalog-registry-identificationplugin/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.registry/catalog-registry-federationadminservice/${project.version}</bundle>
         <bundle>mvn:ddf.catalog.registry/catalog-registry-federationadminserviceimpl/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.registry/catalog-registry-federationadminapi/${project.version}</bundle>
+        <bundle>mvn:ddf.catalog.registry/catalog-registry-federationadminimpl/${project.version}</bundle>
     </feature>
 
 </features>


### PR DESCRIPTION
#### What does this PR do?

FederationAdmin support for registry node editing ui
#### Who is reviewing it?

Was reviewed on the codice PR
#### How should this be tested?
#### Any background context you want to provide?
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Adding federationAdminApi and federationAdminImpl and supporting files and unit tests
  They provide the mbean to bridge the front end and the FederationAdminService
  Adding the createLocalEntry method

Adding RegistryPackageWebConverter for converting between backend and frontend representations of the RegistryObject
  converts a Map to a RegistryPackageType
  converts a RegistryObjectType to a Map

Updating FederationAdminService to include an addLocalEntry that takes a RegistryPackageType
  updating unit tests also

Adding ability to delete registry metacards by registry id
  adding deleteLocalEntry to FederationAdminService and to the FederationAdmin
  updating tests

Adding ability to get local registry entries
  Updating supporting files including tests
  FederationAdminServiceImpl will return a list of RegistryPackageTypes for each local registry metacard found
  FederationAdmin will convert that list into a Map containing a list of RegistryPackageTypes converted using the RegistryPackageWebConverter

  Created a separate ParserConfigurator for unmarshalling

Adding list of transient attributes to the RegistryObjectMetacardType
Adding ability to update local registry entries
  Updating supporting files including tests
  FederationAdminServiceImpl provides two methods to update a metacard. One taking a metacard the other taking a RegistryPackageType.
  FederationAdmin will take in a Map and convert it to a RegistryPackageType and use FederationAdminServiceImpl's update method

Adding custom FederationAdminException
Updating FederationAdmin & FederationAdminService and supporting files to use custom exception

Addressing PR comments
FederationAdmin
  Changing return  type of createLocalEntry to String. Returns metacard id
  Changing methods to go from maps all the way to metacards, calling the FederationAdminServiceImpl with only metacards
  Adding RegistryTransformer and Parser services
  Updating tests

FederationAdminService
  Removing CRUD operations on RegistryPackages, only metacards
  Renaming most of the methods to remove local from name
  Adding deleteRegistryEntriesByMetacardIds, getLocalRegistryMetacards, getLocalRegistryMetacardsByRegistryIds
  Updating tests

RegistryPackageWebConverter
  Adding a check to getRegistryPackageFromWebMap. It will check if the registry package is empty before returning. Setting it to null if it is

Addressing PR comments
FederationAdminService & Impl
  Adding destinations option to the deleteRegistryEntriesByRegistryIds and deleteRegistryEntriesByMetacardIds
  Adding destinations and xml string options to the udpateRegistryEntry
  Updating tests

Addressing PR comments
FederationAdmin MBean interface & impl
  Adding createLocalEntry that takes a Base64 encoded xml string
  Updating tests
