### PR TITLE
DDF-0002 CatalogMetrics isFederated method now handles null sourceId

### DIFF
--- a/catalog/core/catalog-core-metricsplugin/src/main/java/ddf/catalog/metrics/CatalogMetrics.java
+++ b/catalog/core/catalog-core-metricsplugin/src/main/java/ddf/catalog/metrics/CatalogMetrics.java
@@ -17,6 +17,7 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.configuration.SystemInfo;
 
 import com.codahale.metrics.Histogram;
@@ -248,7 +249,8 @@ public final class CatalogMetrics
         } else if (sourceIds == null) {
             return false;
         } else {
-            return (sourceIds.size() > 1) || (sourceIds.size() == 1 && !sourceIds.contains("")
+            return (sourceIds.size() > 1) || (sourceIds.size() == 1 && sourceIds.stream().noneMatch(
+                    StringUtils::isEmpty)
                     && !sourceIds.contains(SystemInfo.getSiteName()));
         }
     }


### PR DESCRIPTION
#### What does this PR do?

Fix CatalogMetrics isFederated method in the case of null sourceId
#### Who is reviewing it?

@clockard @vinamartin @gordocanchola 
#### How should this be tested?

carefully
#### Any background context you want to provide?

fix of a fix
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
