### PR TITLE
DDF-1992 Create AdminRegistryPollerBean to return registry info (Update)

### DIFF
--- a/catalog/spatial/registry/registry-federation-admin-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-federation-admin-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -21,7 +21,6 @@
         <property name="catalogFramework" ref="catalogFramework"/>
         <property name="catalogStoreMap" ref="catalogStoreMap"/>
         <property name="federationAdminService" ref="federationAdminService"/>
-        <property name="filterBuilder" ref="filterBuilder"/>
         <property name="parser" ref="xmlParser"/>
         <property name="registryTransformer" ref="inputTransformer"/>
     </bean>
@@ -32,7 +31,6 @@
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
     <reference id="federationAdminService"
                interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>
-    <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
     <reference id="inputTransformer" interface="ddf.catalog.transform.InputTransformer"
                filter="(id=rim:RegistryPackage)"/>
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"/>


### PR DESCRIPTION
#### What does this PR do?

Changing queries for registry id to add a filter for registry Tag and to use a LIKE comparison because registry id is an Attribute.
#### Who is reviewing it?

@clockard @vinamartin @mcalcote 
#### How should this be tested?

Verify the build
#### Any background context you want to provide?
#### What are the relevant tickets?

DDF-1992
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
  
  Fixing the queries for registry in updatePublications
    The queries were doing an equals on an Attribute but should be a like
    The queries weren't checking for the registry Tag
    Adding the use of FILTER_FACTORY because I'm not too familiar with the filterBuilder. Removed the filterBuilder because it wasn't being used anywhere else
    Combined the population of updatedPublishedLocations and publicLocations to a single iteration over the destinations list
  Removing filter builder from blueprint
