### PR TITLE
DDF-2053 Update source creation from registry entries

### DIFF
--- a/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/opensearch/catalog-opensearch-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -50,7 +50,7 @@
         <property name="name" value="Open Search Endpoint"/>
         <property name="version" value="1.0.0"/>
         <property name="description" value="The endpoint used for open search."/>
-        <property name="bindingType" value="OpenSearchSource"/>
+        <property name="bindingType" value="OpenSearch_1.0.0"/>
     </bean>
     <service ref="ddf.catalog.endpoint.opensearch"
              interface="ddf.catalog.endpoint.CatalogEndpoint"/>

--- a/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/csw/spatial-csw-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -154,7 +154,7 @@
         <property name="name" value="CSW Endpoint"/>
         <property name="version" value="2.0.2"/>
         <property name="description" value="The endpoint used for csw."/>
-        <property name="bindingType" value="Csw_Federated_Source"/>
+        <property name="bindingType" value="CSW_2.0.2"/>
     </bean>
 
     <bean id="validator"

--- a/catalog/spatial/registry/pom.xml
+++ b/catalog/spatial/registry/pom.xml
@@ -97,6 +97,11 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.codice.ddf.registry</groupId>
+                <artifactId>registry-source-configuration-handler</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.codice.ddf.spatial</groupId>
                 <artifactId>spatial-ogc-common</artifactId>
                 <version>${project.version}</version>
@@ -158,5 +163,7 @@
         <module>registry-app</module>
         <module>registry-admin-modules</module>
         <module>registry-report-action-provider</module>
+        <module>registry-source-configuration-handler</module>
+
     </modules>
 </project>

--- a/catalog/spatial/registry/registry-app/pom.xml
+++ b/catalog/spatial/registry/registry-app/pom.xml
@@ -79,6 +79,10 @@
             <groupId>org.codice.ddf.registry</groupId>
             <artifactId>registry-admin-local-ui</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-source-configuration-handler</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/catalog/spatial/registry/registry-app/src/main/resources/features.xml
+++ b/catalog/spatial/registry/registry-app/src/main/resources/features.xml
@@ -45,6 +45,7 @@
         <bundle>mvn:org.codice.ddf.registry/registry-federation-admin-impl/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.registry/registry-admin-remote-ui/${project.version}</bundle>
         <bundle>mvn:org.codice.ddf.registry/registry-admin-local-ui/${project.version}</bundle>
+        <bundle>mvn:org.codice.ddf.registry/registry-source-configuration-handler/${project.version}</bundle>
     </feature>
 
     <feature name="registry-app" install="auto" version="${project.version}"

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
@@ -15,17 +15,12 @@ package org.codice.ddf.registry.identification;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,7 +29,6 @@ import java.util.stream.Collectors;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.Marshaller;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.codice.ddf.parser.Parser;
 import org.codice.ddf.parser.ParserConfigurator;
 import org.codice.ddf.parser.ParserException;
@@ -42,16 +36,6 @@ import org.codice.ddf.registry.common.RegistryConstants;
 import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
 import org.codice.ddf.security.common.Security;
 import org.opengis.filter.Filter;
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.InvalidSyntaxException;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.metatype.AttributeDefinition;
-import org.osgi.service.metatype.MetaTypeInformation;
-import org.osgi.service.metatype.MetaTypeService;
-import org.osgi.service.metatype.ObjectClassDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +56,6 @@ import ddf.catalog.operation.DeleteResponse;
 import ddf.catalog.operation.OperationTransaction;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
-import ddf.catalog.operation.Update;
 import ddf.catalog.operation.UpdateRequest;
 import ddf.catalog.operation.UpdateResponse;
 import ddf.catalog.operation.impl.QueryImpl;
@@ -87,13 +70,7 @@ import ddf.catalog.util.impl.Requests;
 import ddf.security.SecurityConstants;
 import ddf.security.Subject;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.ExternalIdentifierType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectListType;
 import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.ServiceBindingType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.ServiceType;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
-import oasis.names.tc.ebxml_regrep.xsd.rim._3.ValueListType;
 
 /**
  * IdentificationPlugin is a Pre/PostIngestPlugin that assigns a localID when a metacard is added to the
@@ -112,8 +89,6 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
 
     private ParserConfigurator unmarshalConfigurator;
 
-    private ConfigurationAdmin configurationAdmin;
-
     private Set<String> registryIds = ConcurrentHashMap.newKeySet();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IdentificationPlugin.class);
@@ -125,8 +100,6 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
     private static final String ID = "id";
 
     private static final String SHORTNAME = "shortname";
-
-    private MetaTypeService metatype;
 
     @Override
     public CreateRequest process(CreateRequest input)
@@ -219,38 +192,18 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
     @Override
     public CreateResponse process(CreateResponse input) throws PluginExecutionException {
         if (Requests.isLocal(input.getRequest())) {
-            for (Metacard metacard : input.getCreatedMetacards()) {
-                if (metacard.getTags()
-                        .contains(RegistryConstants.REGISTRY_TAG)) {
-                    registryIds.add(getRegistryId(metacard));
-                    try {
-                        updateRegistryConfigurations(metacard);
-                    } catch (IOException | InvalidSyntaxException | ParserException e) {
-                        LOGGER.error(
-                                "Unable to update registry configurations, metacard still ingested");
-                    }
-                }
-            }
+            registryIds.addAll(input.getCreatedMetacards()
+                    .stream()
+                    .filter(metacard -> metacard.getTags()
+                            .contains(RegistryConstants.REGISTRY_TAG))
+                    .map(this::getRegistryId)
+                    .collect(Collectors.toList()));
         }
         return input;
     }
 
     @Override
     public UpdateResponse process(UpdateResponse input) throws PluginExecutionException {
-        if (Requests.isLocal(input.getRequest())) {
-            for (Update update : input.getUpdatedMetacards()) {
-                if (update.getNewMetacard()
-                        .getTags()
-                        .contains(RegistryConstants.REGISTRY_TAG)) {
-                    try {
-                        updateRegistryConfigurations(update.getNewMetacard());
-                    } catch (IOException | InvalidSyntaxException | ParserException e) {
-                        LOGGER.error(
-                                "Unable to update registry configurations, metacard still ingested");
-                    }
-                }
-            }
-        }
         return input;
     }
 
@@ -395,14 +348,6 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
         this.catalogFramework = framework;
     }
 
-    public void setConfigurationAdmin(ConfigurationAdmin configurationAdmin) {
-        this.configurationAdmin = configurationAdmin;
-    }
-
-    public void setMetatype(MetaTypeService metatype) {
-        this.metatype = metatype;
-    }
-
     public void setParser(Parser parser) {
         List<String> contextPath = Arrays.asList(RegistryObjectType.class.getPackage()
                         .getName(),
@@ -417,244 +362,4 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
         this.marshalConfigurator.addProperty(Marshaller.JAXB_FRAGMENT, true);
         this.parser = parser;
     }
-
-    private void updateRegistryConfigurations(Metacard metacard)
-            throws IOException, InvalidSyntaxException, ParserException {
-        String metadata = metacard.getMetadata();
-        InputStream inputStream = new ByteArrayInputStream(metadata.getBytes(Charsets.UTF_8));
-
-        JAXBElement<RegistryObjectType> registryObjectTypeJAXBElement = parser.unmarshal(
-                unmarshalConfigurator,
-                JAXBElement.class,
-                inputStream);
-
-        if (registryObjectTypeJAXBElement != null) {
-            RegistryPackageType registryPackageType =
-                    (RegistryPackageType) registryObjectTypeJAXBElement.getValue();
-            String configId = metacard.getTitle();
-            if (configId == null || configId.isEmpty()) {
-                configId = registryPackageType.getId();
-            }
-            Configuration[] configurations = configurationAdmin.listConfigurations(String.format(
-                    "(id=%s)",
-                    configId));
-            //check for duplicate name situation
-            if (configurations != null && configurations.length > 0) {
-                String regId = (String) configurations[0].getProperties()
-                        .get(RegistryObjectMetacardType.REGISTRY_ID);
-                if (regId == null || !regId.equals(registryPackageType.getId())) {
-                    configId = String.format("%s - %s", configId, registryPackageType.getId());
-                }
-            }
-
-            configurations = configurationAdmin.listConfigurations(String.format("(registry-id=%s)",
-                    registryPackageType.getId()));
-
-            Map<String, Configuration> configMap = new HashMap<>();
-            if (configurations != null && configurations.length > 0) {
-                for (Configuration config : configurations) {
-                    configMap.put((String) config.getProperties()
-                            .get(BINDING_TYPE), config);
-                }
-            }
-            RegistryObjectListType registryObjectListType =
-                    registryPackageType.getRegistryObjectList();
-            for (JAXBElement id : registryObjectListType.getIdentifiable()) {
-                RegistryObjectType registryObject = (RegistryObjectType) id.getValue();
-                if (registryObject instanceof ServiceType
-                        && RegistryConstants.REGISTRY_SERVICE_OBJECT_TYPE.equals(registryObject.getObjectType())) {
-                    ServiceType service = (ServiceType) registryObject;
-
-                    for (ServiceBindingType binding : service.getServiceBinding()) {
-                        Map<String, List<SlotType1>> slotMap =
-                                getSlotMapWithMultipleValues(binding.getSlot());
-
-                        Hashtable<String, Object> serviceConfigurationProperties =
-                                new Hashtable<>();
-
-                        if (slotMap.get(BINDING_TYPE) == null || CollectionUtils.isEmpty(
-                                getSlotStringAttributes(slotMap.get(BINDING_TYPE)
-                                        .get(0)))) {
-                            continue;
-                        }
-                        String factoryPid = getSlotStringAttributes(slotMap.get(BINDING_TYPE)
-                                .get(0)).get(0);
-                        String factoryPidDisabled =
-                                factoryPid.concat(DISABLED_CONFIGURATION_SUFFIX);
-
-                        if (configMap.containsKey(factoryPid)) {
-                            Dictionary<String, Object> props = configMap.get(factoryPid)
-                                    .getProperties();
-                            Enumeration<String> enumeration = props.keys();
-                            while (enumeration.hasMoreElements()) {
-                                String key = enumeration.nextElement();
-                                serviceConfigurationProperties.put(key, props.get(key));
-                            }
-                        } else {
-
-                            Map<String, Object> defaults = getMetatypeDefaults(factoryPid);
-                            serviceConfigurationProperties.putAll(defaults);
-                        }
-
-                        for (Map.Entry slotValue : slotMap.entrySet()) {
-                            if (CollectionUtils.isEmpty(((SlotType1) (((ArrayList) slotValue.getValue()).get(
-                                    0))).getValueList()
-                                    .getValue()
-                                    .getValue())) {
-                                continue;
-                            }
-                            String key =
-                                    ((SlotType1) (((ArrayList) slotValue.getValue()).get(0))).getName();
-                            String value =
-                                    ((SlotType1) (((ArrayList) slotValue.getValue()).get(0))).getValueList()
-                                            .getValue()
-                                            .getValue()
-                                            .get(0);
-                            serviceConfigurationProperties.put(key, value);
-                        }
-                        serviceConfigurationProperties.put(ID, configId);
-                        serviceConfigurationProperties.put(SHORTNAME, configId);
-                        serviceConfigurationProperties.put(RegistryObjectMetacardType.REGISTRY_ID,
-                                registryPackageType.getId());
-
-                        Configuration configuration = configMap.get(factoryPid);
-                        if (configuration == null) {
-                            configuration = configurationAdmin.createFactoryConfiguration(
-                                    factoryPidDisabled,
-                                    null);
-                        }
-                        configuration.update(serviceConfigurationProperties);
-                    }
-
-                }
-            }
-        }
-
-    }
-
-    private Map<String, List<SlotType1>> getSlotMapWithMultipleValues(List<SlotType1> slots) {
-        Map<String, List<SlotType1>> slotMap = new HashMap<>();
-
-        for (SlotType1 slot : slots) {
-            if (!slotMap.containsKey(slot.getName())) {
-                List<SlotType1> slotList = new ArrayList<>();
-                slotList.add(slot);
-
-                slotMap.put(slot.getName(), slotList);
-            } else {
-                slotMap.get(slot.getName())
-                        .add(slot);
-            }
-        }
-        return slotMap;
-    }
-
-    private static List<String> getSlotStringAttributes(SlotType1 slot) {
-        List<String> slotAttributes = new ArrayList<>();
-
-        if (slot.isSetValueList()) {
-            ValueListType valueList = slot.getValueList()
-                    .getValue();
-            if (valueList.isSetValue()) {
-                slotAttributes = valueList.getValue();
-            }
-        }
-
-        return slotAttributes;
-    }
-
-    private Map<String, Object> getMetatypeDefaults(String factoryPid) {
-        Map<String, Object> properties = new HashMap<>();
-        ObjectClassDefinition bundleMetatype = getObjectClassDefinition(factoryPid);
-        if (bundleMetatype != null) {
-            for (AttributeDefinition attributeDef : bundleMetatype.getAttributeDefinitions(
-                    ObjectClassDefinition.ALL)) {
-                if (attributeDef.getID() != null) {
-                    if (attributeDef.getDefaultValue() != null) {
-                        if (attributeDef.getCardinality() == 0) {
-                            properties.put(attributeDef.getID(),
-                                    getAttributeValue(attributeDef.getDefaultValue()[0],
-                                            attributeDef.getType()));
-                        } else {
-                            properties.put(attributeDef.getID(), attributeDef.getDefaultValue());
-                        }
-                    } else if (attributeDef.getCardinality() != 0) {
-                        properties.put(attributeDef.getID(), new String[0]);
-                    }
-                }
-            }
-        }
-
-        return properties;
-    }
-
-    private ObjectClassDefinition getObjectClassDefinition(Bundle bundle, String pid) {
-        Locale locale = Locale.getDefault();
-        if (bundle != null) {
-            if (metatype != null) {
-                MetaTypeInformation mti = metatype.getMetaTypeInformation(bundle);
-                if (mti != null) {
-                    try {
-                        return mti.getObjectClassDefinition(pid, locale.toString());
-                    } catch (IllegalArgumentException e) {
-                        // MetaTypeProvider.getObjectClassDefinition might throw illegal
-                        // argument exception. So we must catch it here, otherwise the
-                        // other configurations will not be shown
-                        // See https://issues.apache.org/jira/browse/FELIX-2390
-                        // https://issues.apache.org/jira/browse/FELIX-3694
-                    }
-                }
-            }
-        }
-
-        // fallback to nothing found
-        return null;
-    }
-
-    private ObjectClassDefinition getObjectClassDefinition(String pid) {
-        Bundle[] bundles = this.getBundleContext()
-                .getBundles();
-        for (int i = 0; i < bundles.length; i++) {
-            try {
-                ObjectClassDefinition ocd = this.getObjectClassDefinition(bundles[i], pid);
-                if (ocd != null) {
-                    return ocd;
-                }
-            } catch (IllegalArgumentException iae) {
-                // don't care
-            }
-        }
-        return null;
-    }
-
-    private Object getAttributeValue(String value, int type) {
-        switch (type) {
-        case AttributeDefinition.BOOLEAN:
-            return Boolean.valueOf(value);
-        case AttributeDefinition.BYTE:
-            return Byte.valueOf(value);
-        case AttributeDefinition.DOUBLE:
-            return Double.valueOf(value);
-        case AttributeDefinition.CHARACTER:
-            return value.toCharArray()[0];
-        case AttributeDefinition.FLOAT:
-            return Float.valueOf(value);
-        case AttributeDefinition.INTEGER:
-            return Integer.valueOf(value);
-        case AttributeDefinition.LONG:
-            return Long.valueOf(value);
-        case AttributeDefinition.SHORT:
-            return Short.valueOf(value);
-        case AttributeDefinition.PASSWORD:
-        case AttributeDefinition.STRING:
-        default:
-            return value;
-        }
-    }
-
-    private BundleContext getBundleContext() {
-        return FrameworkUtil.getBundle(this.getClass())
-                .getBundleContext();
-    }
-
 }

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -18,16 +18,12 @@
                availability="mandatory"/>
 
     <reference id="catalogFramework" interface="ddf.catalog.CatalogFramework"/>
-    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
-    <reference id="metatype" interface="org.osgi.service.metatype.MetaTypeService" />
     <reference id="filterBuilder" interface="ddf.catalog.filter.FilterBuilder"/>
 
     <bean id="identificationPlugin"
           class="org.codice.ddf.registry.identification.IdentificationPlugin" init-method="init">
         <property name="parser" ref="xmlParser"/>
         <property name="catalogFramework" ref="catalogFramework"/>
-        <property name="configurationAdmin" ref="configurationAdmin"/>
-        <property name="metatype" ref="metatype"/>
         <property name="filterBuilder" ref="filterBuilder"/>
     </bean>
 

--- a/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/RegistryPackageUtils.java
+++ b/catalog/spatial/registry/registry-schema-bindings/src/main/java/org/codice/ddf/registry/schemabindings/RegistryPackageUtils.java
@@ -147,6 +147,17 @@ public final class RegistryPackageUtils {
         return slotMap;
     }
 
+    public static Map<String, List<SlotType1>> getNameSlotMapWithMultipleValues(List<SlotType1> slots) {
+        Map<String, List<SlotType1>> slotMap = new HashMap<>();
+
+        for (SlotType1 slot : slots) {
+            slotMap.putIfAbsent(slot.getName(), new ArrayList<>());
+            slotMap.get(slot.getName()).add(slot);
+        }
+
+        return slotMap;
+    }
+
     public static List<String> getSlotStringAttributes(SlotType1 slot) {
         List<String> slotAttributes = new ArrayList<>();
 

--- a/catalog/spatial/registry/registry-source-configuration-handler/pom.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>registry</artifactId>
+        <groupId>org.codice.ddf.registry</groupId>
+        <version>2.9.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>registry-source-configuration-handler</artifactId>
+    <name>DDF :: Registry :: Source :: Configuration :: Handler</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-federation-admin-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-ebrim-transformer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.registry</groupId>
+            <artifactId>registry-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.catalog.core</groupId>
+            <artifactId>catalog-core-api-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.security</groupId>
+            <artifactId>ddf-security-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ddf.platform</groupId>
+            <artifactId>platform-parser-xml</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.name}</Bundle-Name>
+                        <Embed-Dependency>
+                            catalog-core-api-impl;scope=!test,
+                            ddf-security-common
+                        </Embed-Dependency>
+                        <Import-Package>
+                            !org.codice.ddf.platform.util.http,
+                            !org.codice.ddf.platform.util,
+                            *
+                        </Import-Package>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.0</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -1,0 +1,533 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.registry.source.configuration;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.xml.bind.JAXBElement;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.parser.Parser;
+import org.codice.ddf.parser.ParserConfigurator;
+import org.codice.ddf.parser.ParserException;
+import org.codice.ddf.registry.common.RegistryConstants;
+import org.codice.ddf.registry.common.metacard.RegistryObjectMetacardType;
+import org.codice.ddf.registry.schemabindings.RegistryPackageUtils;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.event.Event;
+import org.osgi.service.event.EventHandler;
+import org.osgi.service.metatype.AttributeDefinition;
+import org.osgi.service.metatype.MetaTypeInformation;
+import org.osgi.service.metatype.MetaTypeService;
+import org.osgi.service.metatype.ObjectClassDefinition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Charsets;
+
+import ddf.catalog.data.Attribute;
+import ddf.catalog.data.Metacard;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryObjectType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.RegistryPackageType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.ServiceBindingType;
+import oasis.names.tc.ebxml_regrep.xsd.rim._3.SlotType1;
+
+public class SourceConfigurationHandler implements EventHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SourceConfigurationHandler.class);
+
+    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
+
+    private static final String BINDING_TYPE = "bindingType";
+
+    private static final String DISABLED_CONFIGURATION_SUFFIX = "_disabled";
+
+    private static final String ID = "id";
+
+    private static final String SHORTNAME = "shortname";
+
+    private static final String DELETE_CONFIGURATION = "deleteConfiguration";
+
+    private ConfigurationAdmin configurationAdmin;
+
+    private MetaTypeService metaTypeService;
+
+    private Parser parser;
+
+    private ParserConfigurator unmarshalConfigurator;
+
+    private ExecutorService executor;
+
+    private int threadPoolSize = 1;
+
+    private String urlBindingName;
+
+    private Map<String, String> bindingTypeToFactoryPidMap = new HashMap<>();
+
+    private List<String> sourceActivationPriorityOrder = new ArrayList<>();
+
+    private Boolean activateSourceOnCreation;
+
+    public SourceConfigurationHandler() {
+    }
+
+    public void init() {
+        executor = Executors.newFixedThreadPool(threadPoolSize);
+    }
+
+    public void destroy() {
+        executor.shutdown();
+    }
+
+    @Override
+    public void handleEvent(Event event) {
+        LOGGER.debug("Received event");
+        Metacard mcard = (Metacard) event.getProperty(METACARD_PROPERTY);
+        if (mcard == null) {
+            return;
+        }
+        if (mcard.getTags()
+                .contains(RegistryConstants.REGISTRY_TAG)) {
+            executor.execute(() -> {
+                if (event.getTopic()
+                        .equals("ddf/catalog/event/CREATED")) {
+                    processCreate(mcard);
+                } else if (event.getTopic()
+                        .equals("ddf/catalog/event/UPDATED")) {
+                    processUpdate(mcard);
+                }
+            });
+        }
+    }
+
+    private void processCreate(Metacard metacard) {
+        try {
+            updateRegistryConfigurations(metacard);
+        } catch (IOException | InvalidSyntaxException | ParserException e) {
+            LOGGER.error("Unable to update registry configurations, metacard still ingested");
+        }
+    }
+
+    private void processUpdate(Metacard metacard) {
+        try {
+            updateRegistryConfigurations(metacard);
+        } catch (IOException | InvalidSyntaxException | ParserException e) {
+            LOGGER.error("Unable to update registry configurations, metacard still ingested");
+        }
+    }
+
+    private void updateRegistryConfigurations(Metacard metacard)
+            throws IOException, InvalidSyntaxException, ParserException {
+        String metadata = metacard.getMetadata();
+        InputStream inputStream = new ByteArrayInputStream(metadata.getBytes(Charsets.UTF_8));
+
+        Attribute identityNode =
+                metacard.getAttribute(RegistryObjectMetacardType.REGISTRY_IDENTITY_NODE);
+        if (identityNode != null) {
+            return;
+        }
+
+        JAXBElement<RegistryObjectType> registryObjectTypeJAXBElement = parser.unmarshal(
+                unmarshalConfigurator,
+                JAXBElement.class,
+                inputStream);
+
+        if (registryObjectTypeJAXBElement == null) {
+            LOGGER.error("Error trying to unmarshal metadata for metacard id: {}. Metadata: {}",
+                    metacard.getId(),
+                    metadata);
+            return;
+        }
+
+        RegistryPackageType registryPackage =
+                (RegistryPackageType) registryObjectTypeJAXBElement.getValue();
+
+        String configId = metacard.getTitle();
+        if (StringUtils.isEmpty(configId)) {
+            configId = registryPackage.getId();
+        }
+
+        Configuration[] configurations = configurationAdmin.listConfigurations(String.format(
+                "(id=%s)",
+                configId));
+
+        // check for duplicate name situation
+        if (configurations != null && configurations.length > 0) {
+            String registryId = (String) configurations[0].getProperties()
+                    .get(RegistryObjectMetacardType.REGISTRY_ID);
+            if (registryId == null || !registryId.equals(registryPackage.getId())) {
+                configId = String.format("%s - %s", configId, registryPackage.getId());
+            }
+        }
+
+        configurations = configurationAdmin.listConfigurations(String.format("(%s=%s)",
+                RegistryObjectMetacardType.REGISTRY_ID,
+                registryPackage.getId()));
+
+        List<ServiceBindingType> bindingTypes =
+                RegistryPackageUtils.getBindingTypes(registryPackage);
+        String bindingTypeToActivate = getBindingTypeToActivate(bindingTypes);
+        String deletedActiveConfigurationFPid = null;
+        String deletedDisabledConfigurationFPid = null;
+        Hashtable<String, Object> deletedActiveConfigurationProperties = new Hashtable<>();
+        Hashtable<String, Object> deletedDisabledConfigurationProperties = new Hashtable<>();
+
+        Map<String, Configuration> configMap = new HashMap<>();
+        if (configurations != null && configurations.length > 0) {
+            boolean activeHandled = false;
+            for (Configuration configuration : configurations) {
+                configMap.put(configuration.getFactoryPid(), configuration);
+
+                if (activateSourceOnCreation & !activeHandled) {
+                    String fPidToActivate = bindingTypeToFactoryPidMap.get(bindingTypeToActivate);
+
+                    if (configuration.getFactoryPid()
+                            .equals(fPidToActivate)) {
+                        activeHandled = true;
+                    } else if (!configuration.getFactoryPid()
+                            .contains(DISABLED_CONFIGURATION_SUFFIX)) {
+                        String factoryPidDisabled = configuration.getFactoryPid()
+                                .concat(DISABLED_CONFIGURATION_SUFFIX);
+                        deletedActiveConfigurationFPid = configuration.getFactoryPid();
+                        deletedActiveConfigurationProperties.putAll(getConfigurationsFromDictionary(
+                                configuration.getProperties()));
+
+                        configMap.remove(configuration.getFactoryPid());
+
+                        configuration.delete();
+                        configurationAdmin.createFactoryConfiguration(factoryPidDisabled, null);
+
+                    } else if (configuration.getFactoryPid()
+                            .equals(fPidToActivate.concat(DISABLED_CONFIGURATION_SUFFIX))) {
+                        deletedDisabledConfigurationFPid = configuration.getFactoryPid();
+                        deletedDisabledConfigurationProperties.putAll(
+                                getConfigurationsFromDictionary(configuration.getProperties()));
+                        configMap.remove(configuration.getFactoryPid());
+
+                        configuration.delete();
+                    }
+                }
+            }
+        }
+
+        for (ServiceBindingType bindingType : bindingTypes) {
+            Map<String, List<SlotType1>> slotMap =
+                    RegistryPackageUtils.getNameSlotMapWithMultipleValues(bindingType.getSlot());
+
+            Hashtable<String, Object> serviceConfigurationProperties = new Hashtable<>();
+
+            if (slotMap.get(BINDING_TYPE) == null
+                    || CollectionUtils.isEmpty(RegistryPackageUtils.getSlotStringAttributes(slotMap.get(
+                    BINDING_TYPE)
+                    .get(0)))) {
+                continue;
+            }
+
+            String factoryPidMask = RegistryPackageUtils.getSlotStringAttributes(slotMap.get(
+                    BINDING_TYPE)
+                    .get(0))
+                    .get(0);
+            String factoryPid = bindingTypeToFactoryPidMap.get(factoryPidMask);
+
+            if (StringUtils.isBlank(factoryPid)) {
+                continue;
+            }
+
+            String factoryPidDisabled = factoryPid.concat(DISABLED_CONFIGURATION_SUFFIX);
+
+            if (configMap.containsKey(factoryPid)) {
+                Dictionary<String, Object> properties = configMap.get(factoryPid)
+                        .getProperties();
+                serviceConfigurationProperties.putAll(getConfigurationsFromDictionary(properties));
+
+            } else if (configMap.containsKey(factoryPidDisabled)) {
+                Dictionary<String, Object> properties = configMap.get(factoryPidDisabled)
+                        .getProperties();
+                serviceConfigurationProperties.putAll(getConfigurationsFromDictionary(properties));
+            } else {
+                if (activateSourceOnCreation) {
+                    if (factoryPid.equals(deletedActiveConfigurationFPid)) {
+                        serviceConfigurationProperties.putAll(deletedActiveConfigurationProperties);
+                    } else if (factoryPidDisabled.equals(deletedDisabledConfigurationFPid)) {
+                        serviceConfigurationProperties.putAll(deletedDisabledConfigurationProperties);
+                    } else {
+                        Map<String, Object> defaults = getMetatypeDefaults(factoryPid);
+                        serviceConfigurationProperties.putAll(defaults);
+                    }
+                } else {
+                    Map<String, Object> defaults = getMetatypeDefaults(factoryPid);
+                    serviceConfigurationProperties.putAll(defaults);
+                }
+            }
+
+            String bindingName = null;
+            for (Map.Entry slotMapEntry : slotMap.entrySet()) {
+                SlotType1 mapSlot = (SlotType1) ((ArrayList) slotMapEntry.getValue()).get(0);
+                List<String> slotAttributes = RegistryPackageUtils.getSlotStringAttributes(mapSlot);
+                if (CollectionUtils.isEmpty(slotAttributes)) {
+                    continue;
+                }
+
+                String name = (String) slotMapEntry.getKey();
+                String value = slotAttributes.get(0);
+                serviceConfigurationProperties.put(name, value);
+                if (name.equals(urlBindingName)) {
+                    bindingName = value;
+                }
+
+            }
+            serviceConfigurationProperties.put(ID, configId);
+            serviceConfigurationProperties.put(SHORTNAME, configId);
+            serviceConfigurationProperties.put(RegistryObjectMetacardType.REGISTRY_ID,
+                    registryPackage.getId());
+            if (StringUtils.isNotBlank(bindingName) && bindingType.isSetAccessURI()) {
+                serviceConfigurationProperties.put(bindingName, bindingType.getAccessURI());
+            }
+
+            Configuration configuration = configMap.get(factoryPid);
+            if (configuration == null) {
+
+                configuration = configMap.get(factoryPidDisabled);
+                if (configuration == null) {
+
+                    String pid = factoryPidDisabled;
+                    if (activateSourceOnCreation && factoryPidMask.equals(bindingTypeToActivate)) {
+                        pid = factoryPid;
+                    }
+                    configuration = configurationAdmin.createFactoryConfiguration(pid, null);
+                }
+            }
+            configuration.update(serviceConfigurationProperties);
+        }
+
+    }
+
+    private String getBindingTypeToActivate(List<ServiceBindingType> bindingTypes) {
+        if (CollectionUtils.isEmpty(sourceActivationPriorityOrder)) {
+            return null;
+        }
+
+        String bindingTypeToActivate = null;
+        String topPriority = sourceActivationPriorityOrder.get(0);
+        List<String> bindingTypesNames = new ArrayList<>();
+
+        for (ServiceBindingType bindingType : bindingTypes) {
+            Map<String, List<SlotType1>> slotMap =
+                    RegistryPackageUtils.getNameSlotMapWithMultipleValues(bindingType.getSlot());
+
+            if (slotMap.get(BINDING_TYPE) == null
+                    || CollectionUtils.isEmpty(RegistryPackageUtils.getSlotStringAttributes(slotMap.get(
+                    BINDING_TYPE)
+                    .get(0)))) {
+                continue;
+            }
+
+            String factoryPidMask = RegistryPackageUtils.getSlotStringAttributes(slotMap.get(
+                    BINDING_TYPE)
+                    .get(0))
+                    .get(0);
+
+            if (StringUtils.isNotBlank(factoryPidMask)) {
+                if (factoryPidMask.equals(topPriority)) {
+                    return factoryPidMask;
+                }
+
+                bindingTypesNames.add(factoryPidMask);
+            }
+        }
+
+        for (String prioritySource : sourceActivationPriorityOrder.subList(1,
+                sourceActivationPriorityOrder.size())) {
+            if (bindingTypesNames.contains(prioritySource)) {
+                return prioritySource;
+            }
+        }
+
+        return bindingTypeToActivate;
+    }
+
+    private Hashtable<String, Object> getConfigurationsFromDictionary(
+            Dictionary<String, Object> properties) {
+        Hashtable<String, Object> configProperties = new Hashtable<>();
+
+        Enumeration<String> enumeration = properties.keys();
+        while (enumeration.hasMoreElements()) {
+            String key = enumeration.nextElement();
+            configProperties.put(key, properties.get(key));
+        }
+
+        return configProperties;
+    }
+
+    private Map<String, Object> getMetatypeDefaults(String factoryPid) {
+        Map<String, Object> properties = new HashMap<>();
+        ObjectClassDefinition bundleMetatype = getObjectClassDefinition(factoryPid);
+        if (bundleMetatype != null) {
+            for (AttributeDefinition attributeDef : bundleMetatype.getAttributeDefinitions(
+                    ObjectClassDefinition.ALL)) {
+                if (attributeDef.getID() != null) {
+                    if (attributeDef.getDefaultValue() != null) {
+                        if (attributeDef.getCardinality() == 0) {
+                            properties.put(attributeDef.getID(),
+                                    getAttributeValue(attributeDef.getDefaultValue()[0],
+                                            attributeDef.getType()));
+                        } else {
+                            properties.put(attributeDef.getID(), attributeDef.getDefaultValue());
+                        }
+                    } else if (attributeDef.getCardinality() != 0) {
+                        properties.put(attributeDef.getID(), new String[0]);
+                    }
+                }
+            }
+        }
+
+        return properties;
+    }
+
+    private ObjectClassDefinition getObjectClassDefinition(String pid) {
+        Bundle[] bundles = this.getBundleContext()
+                .getBundles();
+        for (int i = 0; i < bundles.length; i++) {
+            try {
+                ObjectClassDefinition ocd = this.getObjectClassDefinition(bundles[i], pid);
+                if (ocd != null) {
+                    return ocd;
+                }
+            } catch (IllegalArgumentException iae) {
+                // don't care
+            }
+        }
+        return null;
+    }
+
+    private ObjectClassDefinition getObjectClassDefinition(Bundle bundle, String pid) {
+        Locale locale = Locale.getDefault();
+        if (bundle != null) {
+            if (metaTypeService != null) {
+                MetaTypeInformation mti = metaTypeService.getMetaTypeInformation(bundle);
+                if (mti != null) {
+                    try {
+                        return mti.getObjectClassDefinition(pid, locale.toString());
+                    } catch (IllegalArgumentException e) {
+                        // MetaTypeProvider.getObjectClassDefinition might throw illegal
+                        // argument exception. So we must catch it here, otherwise the
+                        // other configurations will not be shown
+                        // See https://issues.apache.org/jira/browse/FELIX-2390
+                        // https://issues.apache.org/jira/browse/FELIX-3694
+                    }
+                }
+            }
+        }
+
+        // fallback to nothing found
+        return null;
+    }
+
+    private Object getAttributeValue(String value, int type) {
+        switch (type) {
+        case AttributeDefinition.BOOLEAN:
+            return Boolean.valueOf(value);
+        case AttributeDefinition.BYTE:
+            return Byte.valueOf(value);
+        case AttributeDefinition.DOUBLE:
+            return Double.valueOf(value);
+        case AttributeDefinition.CHARACTER:
+            return value.toCharArray()[0];
+        case AttributeDefinition.FLOAT:
+            return Float.valueOf(value);
+        case AttributeDefinition.INTEGER:
+            return Integer.valueOf(value);
+        case AttributeDefinition.LONG:
+            return Long.valueOf(value);
+        case AttributeDefinition.SHORT:
+            return Short.valueOf(value);
+        case AttributeDefinition.PASSWORD:
+        case AttributeDefinition.STRING:
+        default:
+            return value;
+        }
+    }
+
+    private BundleContext getBundleContext() {
+        return FrameworkUtil.getBundle(this.getClass())
+                .getBundleContext();
+    }
+
+    public void setActivateSourceOnCreation(Boolean activateSourceOnCreation) {
+        this.activateSourceOnCreation = activateSourceOnCreation;
+    }
+
+    public void setBindingTypeFactoryPid(List<String> bindingTypeFactoryPid) {
+        bindingTypeToFactoryPidMap = new HashMap<>();
+
+        for (String mapping : bindingTypeFactoryPid) {
+            String bindingType = StringUtils.substringBefore(mapping, "=");
+            String factoryPid = StringUtils.substringAfter(mapping, "=");
+
+            if (StringUtils.isNotBlank(bindingType) && StringUtils.isNotBlank(factoryPid)) {
+                bindingTypeToFactoryPidMap.put(bindingType, factoryPid);
+            }
+        }
+    }
+
+    public void setSourceActivationPriorityOrder(List<String> sourceActivationPriorityOrder) {
+        this.sourceActivationPriorityOrder = sourceActivationPriorityOrder;
+    }
+
+    public void setUrlBindingName(String urlBindingName) {
+        this.urlBindingName = urlBindingName;
+    }
+
+    public void setConfigurationAdmin(ConfigurationAdmin configurationAdmin) {
+        this.configurationAdmin = configurationAdmin;
+    }
+
+    public void setMetaTypeService(MetaTypeService metaTypeService) {
+        this.metaTypeService = metaTypeService;
+    }
+
+    public void setParser(Parser parser) {
+        List<String> contextPath = Arrays.asList(RegistryObjectType.class.getPackage()
+                        .getName(),
+                net.opengis.ogc.ObjectFactory.class.getPackage()
+                        .getName(),
+                net.opengis.gml.v_3_1_1.ObjectFactory.class.getPackage()
+                        .getName());
+        ClassLoader classLoader = this.getClass()
+                .getClassLoader();
+
+        this.unmarshalConfigurator = parser.configureParser(contextPath, classLoader);
+        this.parser = parser;
+    }
+
+}

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.1.0">
+
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+    <reference id="eventAdmin" interface="org.codice.ddf.parser.Parser" availability="mandatory"/>
+    <!--<reference id="federationAdminService" interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>-->
+    <reference id="metaTypeService" interface="org.osgi.service.metatype.MetaTypeService" />
+    <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)" availability="mandatory"/>
+
+    <bean id="sourceConfigurationHandler" class="org.codice.ddf.registry.source.configuration.SourceConfigurationHandler" init-method="init">
+        <cm:managed-properties persistent-id="Registry_Configuration_Event_Handler" update-strategy="container-managed"/>
+        <property name="urlBindingName" value="urlBindingName"/>
+        <property name="bindingTypeFactoryPid">
+            <list value-type="java.lang.String">
+                <value>CSW_2.0.2=Csw_Federated_Source</value>
+                <value>WFS_1.0.0=Wfs_v1_0_0_Federated_Source</value>
+                <value>OpenSearch_1.0.0=OpenSearchSource</value>
+            </list>
+        </property>
+        <property name="activateSourceOnCreation" value="false"/>
+        <property name="sourceActivationPriorityOrder">
+            <list value-type="java.lang.String">
+                <value>CSW_2.0.2</value>
+                <value>WFS_1.0.0</value>
+                <value>OpenSearch_1.0.0</value>
+            </list>
+        </property>
+
+        <property name="configurationAdmin" ref="configurationAdmin"/>
+        <property name="metaTypeService" ref="metaTypeService"/>
+        <property name="parser" ref="xmlParser"/>
+    </bean>
+
+    <service ref="sourceConfigurationHandler" interface="org.osgi.service.event.EventHandler">
+        <service-properties>
+            <entry key="event.topics">
+                <array value-type="java.lang.String">
+                    <value>ddf/catalog/event/CREATED</value>
+                    <value>ddf/catalog/event/UPDATED</value>
+                    <value>ddf/catalog/event/DELETED</value>
+                </array>
+            </entry>
+        </service-properties>
+    </service>
+</blueprint>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<metatype:MetaData xmlns:metatype="http://www.osgi.org/xmlns/metatype/v1.0.0">
+
+    <OCD description="Configurable values for the registry source configuration handler"
+         name="Registry Source Configuration Handler"
+         id="Registry_Configuration_Event_Handler">
+
+        <AD name="Url Binding Name" id="urlBindingName" required="true"
+            type="String" default="urlBindingName"
+            description="The url name for communicating with the specific instance."/>
+
+        <AD name="BindingType to Factory PID" id="bindingTypeFactoryPid" required="true"
+            type="String" cardinality="100"
+            default="CSW_2.0.2=Csw_Federated_Source,WFS_1.0.0=Wfs_v1_0_0_Federated_Source,OpenSearch_1.0.0=OpenSearchSource"
+            description="Key/Value mappings of binding type to factory PID"/>
+
+        <AD name="Activate Source on Creation" id="activateSourceOnCreation" required="true"
+            type="Boolean" default="false"
+            description="Flag used to determine if a source should be activated on creation"/>
+
+        <AD name="Source Activation Priority Order" id="sourceActivationPriorityOrder" required="true" type="String" cardinality="100"
+            default="CSW_2.0.2,WFS_1.0.0,OpenSearch_1.0.0" description="This is the priority list used to determine which source should be activated on creation"/>
+
+    </OCD>
+    <Designate pid="Registry_Configuration_Event_Handler">
+        <Object ocdref="Registry_Configuration_Event_Handler"/>
+    </Designate>
+</metatype:MetaData>

--- a/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/wfs/1.0.0/spatial-wfs-v1_0_0-endpoint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -82,7 +82,7 @@
         <property name="name" value="WFS Endpoint"/>
         <property name="version" value="1.0.0"/>
         <property name="description" value="The endpoint used for wfs."/>
-        <property name="bindingType" value="Wfs_v1_0_0_Federated_Source"/>
+        <property name="bindingType" value="WFS_1.0.0"/>
     </bean>
     <service ref="ddf.catalog.endpoint.wfs" interface="ddf.catalog.endpoint.CatalogEndpoint"/>
 


### PR DESCRIPTION
#### What does this PR do?

Moves source configuration logic to a new handler that handles update and create events.
Adds a bindingType -> factoryPid mapping
Adds a flag and priority list that handle activating a source on creation
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@mcalcote @vinamartin @clockard @brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
#### How should this be tested?

Verify the build
#### Any background context you want to provide?

Tests to be written later
#### What are the relevant tickets?

DDF-2053
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests

Adding an event handler that listens for update and create events to process registry source configuration updates
  Moving the updateRegistryConfigurations from IdentificationPlugin to the new handler

Adding Metatype for the even handler configurable values:
  Adding flag for activating a source onf creation
  Adding a priority list used to determine which source to activate on creation
  Adding a binding type -> factory pid mapping
  Adding urlBindingName

Updating blueprint files to use the new binding type instead of factory PID
