### PR TITLE
DDF-1964-SourceUI

### DIFF
--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Accordion.collection.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Accordion.collection.js
@@ -14,25 +14,12 @@
  **/
 /*global define*/
 define([
-    'text!templates/emptyView.handlebars',
-    'marionette',
-    'icanhaz'
-], function(emptyViewTemplate, Marionette, ich) {
+        'backbone',
+        'js/model/Accordion.js'
+    ],
+    function(Backbone, Accordion) {
 
-    if (!ich.emptyViewTemplate) {
-        ich.addTemplate('emptyViewTemplate', emptyViewTemplate);
-    }
-
-    var EmptyView = {};
-
-    EmptyView.sources = Marionette.ItemView.extend({
-        template: 'emptyViewTemplate',
-        serializeData: function() {
-            return {
-                message: "There are no sources configured."
-            };
-        }
+        return Backbone.Collection.extend({
+            model: Accordion
+        });
     });
-
-    return EmptyView;
-});

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Accordion.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Accordion.js
@@ -14,25 +14,11 @@
  **/
 /*global define*/
 define([
-    'text!templates/emptyView.handlebars',
-    'marionette',
-    'icanhaz'
-], function(emptyViewTemplate, Marionette, ich) {
+        'backbone'
+    ],
+    function(Backbone) {
 
-    if (!ich.emptyViewTemplate) {
-        ich.addTemplate('emptyViewTemplate', emptyViewTemplate);
-    }
+        return Backbone.Model.extend({
 
-    var EmptyView = {};
-
-    EmptyView.sources = Marionette.ItemView.extend({
-        template: 'emptyViewTemplate',
-        serializeData: function() {
-            return {
-                message: "There are no sources configured."
-            };
-        }
+        });
     });
-
-    return EmptyView;
-});

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Organization.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Organization.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define(['backbone'],
+    function(Backbone) {
+
+        var Organization = {};
+
+        Organization = Backbone.Model.extend({
+
+            // Defaults set to 'Not Provided' to indicate the software correctly pulled the Organizational Info
+            // but the user did not enter any. N/A was determined to be too vague
+            defaults: {
+                name: 'Not Provided',
+                address: 'Not Provided',
+                phoneNumber: 'Not Provided',
+                emailAddress: 'Not Provided'
+            },
+
+            initializeFromOrganization: function(org) {
+                this.name = org.name;
+                this.address = org.address;
+                this.phoneNumber = org.phoneNumber;
+                this.emailAddress = org.emailAddress;
+            }
+        });
+
+        return Organization;
+    });

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Service.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Service.js
@@ -14,7 +14,7 @@
  **/
 /*global define*/
 /*jshint -W024*/
-define(function (require) {
+define(function(require) {
 
     var Backbone = require('backbone'),
         $ = require('jquery'),
@@ -44,14 +44,12 @@ define(function (require) {
                 properties: new Service.Properties()
             };
         },
-        relations: [
-            {
-                type: Backbone.One,
-                key: 'properties',
-                relatedModel: Service.Properties,
-                includeInJSON: true
-            }
-        ],
+        relations: [{
+            type: Backbone.One,
+            key: 'properties',
+            relatedModel: Service.Properties,
+            includeInJSON: true
+        }],
 
         initialize: function(options) {
             if (options.service) {
@@ -65,7 +63,7 @@ define(function (require) {
          * @param pid The pid id.
          * @returns {{type: string, mbean: string, operation: string}}
          */
-        collectedData: function (pid) {
+        collectedData: function(pid) {
             var model = this;
             var data = {
                 type: 'EXEC',
@@ -82,17 +80,18 @@ define(function (require) {
          * @param model, this is really this model.
          * @returns an ajax promise
          */
-        makeConfigCall: function (model) {
+        makeConfigCall: function(model) {
             if (!model) {
                 return;
             }
             var configUrl = [model.configUrl, "createFactoryConfiguration", model.get("fpid")].join("/");
-            return $.ajax({type: 'GET',
+            return $.ajax({
+                type: 'GET',
                 url: configUrl
             });
         },
 
-        makeEnableCall: function(){
+        makeEnableCall: function() {
             var model = this;
             var pid = model.get('id');
             var url = [model.configUrl, "enableConfiguration", pid].join("/");
@@ -100,12 +99,12 @@ define(function (require) {
                 return $.ajax({
                     url: url,
                     dataType: 'json'
-                }).done(function(){
+                }).done(function() {
                     // massage some data to match the new backend pid.
                     model.trigger('enabled');
                     //enabling the model means the PID will be regenerated. This model no longer exists on the server.
                     model.destroy();
-                }).fail(function(){
+                }).fail(function() {
                     new Error('Could not enable configuratoin ' + pid);
                 });
             }
@@ -114,7 +113,7 @@ define(function (require) {
 
         },
 
-        makeDisableCall: function(){
+        makeDisableCall: function() {
             var model = this;
             var pid = model.get('id');
             var url = [model.configUrl, "disableConfiguration", pid].join("/");
@@ -122,11 +121,11 @@ define(function (require) {
                 return $.ajax({
                     url: url,
                     dataType: 'json'
-                }).done(function(){
+                }).done(function() {
                     model.trigger('disabled');
                     //disabling the model means the PID will be regenerated. This model no longer exists on the server.
                     model.destroy();
-                }).fail(function(){
+                }).fail(function() {
                     new Error('Could not disable configuration ' + pid);
                 });
             }
@@ -137,24 +136,23 @@ define(function (require) {
         // Used to make a call to the backend to disable the service that corresponds to the pid.
         // Note: this does NOT affect the service the function is called on.
         // Treat this as a static function
-        makeDisableCallByPid: function(pid){
-           var url = [this.configUrl, "disableConfiguration", pid].join("/");
-           return $.ajax({
-               url: url,
-               dataType: 'json'
-           });
+        makeDisableCallByPid: function(pid) {
+            var url = [this.configUrl, "disableConfiguration", pid].join("/");
+            return $.ajax({
+                url: url,
+                dataType: 'json'
+            });
         },
-
         /**
          * When a model calls save the sync is called in Backbone.  I override it because this isn't a typical backbone
          * object
          * @return Return a deferred which is a handler with the success and failure callback.
          */
-        sync: function () {
+        sync: function() {
             var deferred = $.Deferred(),
                 model = this;
             //if it has a pid we are editing an existing record
-            if(model.id) {
+            if (model.id) {
                 var collect = model.collectedData(model.id);
                 var jData = JSON.stringify(collect);
 
@@ -163,14 +161,14 @@ define(function (require) {
                     contentType: 'application/json',
                     data: jData,
                     url: model.configUrl
-                }).done(function (result) {
-                        deferred.resolve(result);
-                    }).fail(function (error) {
-                        deferred.fail(error);
-                    });
-             //no pid means this is a new record
+                }).done(function(result) {
+                    deferred.resolve(result);
+                }).fail(function(error) {
+                    deferred.fail(error);
+                });
+                //no pid means this is a new record
             } else {
-                model.makeConfigCall(model).done(function (data) {
+                model.makeConfigCall(model).done(function(data) {
                     var collect = model.collectedData(JSON.parse(data).value);
                     var jData = JSON.stringify(collect);
 
@@ -179,12 +177,12 @@ define(function (require) {
                         contentType: 'application/json',
                         data: jData,
                         url: model.configUrl
-                    }).done(function (result) {
+                    }).done(function(result) {
                         deferred.resolve(result);
-                    }).fail(function (error) {
+                    }).fail(function(error) {
                         deferred.fail(error);
                     });
-                }).fail(function (error) {
+                }).fail(function(error) {
                     deferred.fail(error);
                 });
             }
@@ -194,7 +192,7 @@ define(function (require) {
             var model = this,
                 addUrl = [model.configUrl, "add"].join("/");
 
-            model.makeConfigCall(model).done(function (data) {
+            model.makeConfigCall(model).done(function(data) {
                 var collect = model.collectedData(JSON.parse(data).value);
                 var jData = JSON.stringify(collect);
 
@@ -203,12 +201,12 @@ define(function (require) {
                     contentType: 'application/json',
                     data: jData,
                     url: addUrl
-                }).done(function (result) {
+                }).done(function(result) {
                     deferred.resolve(result);
-                }).fail(function (error) {
+                }).fail(function(error) {
                     deferred.fail(error);
                 });
-            }).fail(function (error) {
+            }).fail(function(error) {
                 deferred.fail(error);
             });
         },
@@ -223,16 +221,22 @@ define(function (require) {
             return $.ajax({
                 type: 'GET',
                 url: deleteUrl
-            }).done(function (result) {
-                  deferred.resolve(result);
-                }).fail(function (error) {
-                    deferred.fail(error);
-                });
+            }).done(function(result) {
+                deferred.resolve(result);
+            }).fail(function(error) {
+                deferred.fail(error);
+            });
         },
         initializeFromMSF: function(msf) {
-            this.set({"fpid":msf.get("id")});
-            this.set({"name":msf.get("name")});
-            this.get('properties').set({"service.factoryPid": msf.get("id")});
+            this.set({
+                "fpid": msf.get("id")
+            });
+            this.set({
+                "name": msf.get("name")
+            });
+            this.get('properties').set({
+                "service.factoryPid": msf.get("id")
+            });
             this.initializeFromService(msf);
         },
         initializeFromService: function(service) {
@@ -253,7 +257,7 @@ define(function (require) {
             if (!_.isUndefined(idModel)) {
                 model.set('properties', new Service.Properties(idModel.get('defaultValue')));
             }
-            metatype.forEach(function(obj){
+            metatype.forEach(function(obj) {
                 var id = obj.get('id');
                 var val = obj.get('defaultValue');
                 if (id !== 'id') {
@@ -262,8 +266,8 @@ define(function (require) {
             });
         },
         /**
-         * Returns the Service.Model used to create this configuration. If the 'service' property is set, that value 
-         * is returned. Otherwise, the service is retrieved by looking it up from the configuration collection relation. 
+         * Returns the Service.Model used to create this configuration. If the 'service' property is set, that value
+         * is returned. Otherwise, the service is retrieved by looking it up from the configuration collection relation.
          */
         getService: function() {
             return this.get('service') || this.collection.parents[0];
@@ -272,7 +276,7 @@ define(function (require) {
 
     Service.ConfigurationList = Backbone.Collection.extend({
         model: Service.Configuration,
-        comparator: function(model){
+        comparator: function(model) {
             return model.get('id');
         }
     });
@@ -285,38 +289,41 @@ define(function (require) {
                 configurations: new Service.ConfigurationList()
             };
         },
-        relations: [
-            {
-                type: Backbone.Many,
-                key: 'configurations',
-                relatedModel: Service.Configuration,
-                collectionType: Service.ConfigurationList,
-                includeInJSON: true
-            },
-            {
-                type: Backbone.Many,
-                key: 'metatype',
-                relatedModel: Service.Metatype,
-                includeInJSON: false
-            }
-        ],
+        relations: [{
+            type: Backbone.Many,
+            key: 'configurations',
+            relatedModel: Service.Configuration,
+            collectionType: Service.ConfigurationList,
+            includeInJSON: true
+        }, {
+            type: Backbone.Many,
+            key: 'metatype',
+            relatedModel: Service.Metatype,
+            includeInJSON: false
+        }],
 
         hasConfiguration: function() {
-            if(this.configuration) {
+            if (this.configuration) {
                 return true;
             }
             return false;
         },
         initializeFromMSF: function(msf) {
-            this.set({"fpid":msf.get("id")});
-            this.set({"name":msf.get("name")});
+            this.set({
+                "fpid": msf.get("id")
+            });
+            this.set({
+                "name": msf.get("name")
+            });
             this.initializeConfigurationFromMetatype(msf.get("metatype"));
-            this.configuration.set({"service.factoryPid": msf.get("id")});
+            this.configuration.set({
+                "service.factoryPid": msf.get("id")
+            });
         },
         initializeConfigurationFromMetatype: function(metatype) {
             var src = this;
             src.configuration = new Service.Configuration();
-            metatype.forEach(function(obj){
+            metatype.forEach(function(obj) {
                 var id = obj.id;
                 var val = obj.defaultValue;
                 src.configuration.set(id, (val) ? val.toString() : null);
@@ -326,16 +333,43 @@ define(function (require) {
 
     Service.Response = Backbone.AssociatedModel.extend({
         url: "/jolokia/exec/org.codice.ddf.catalog.admin.poller.AdminPollerServiceBean:service=admin-source-poller-service/allSourceInfo",
-        relations: [
-            {
-                type: Backbone.Many,
-                key: 'value',
-                relatedModel: Service.Model,
-                includeInJSON: false
-            }
-        ]
+        relations: [{
+            type: Backbone.Many,
+            key: 'value',
+            relatedModel: Service.Model,
+            includeInJSON: false
+        }]
     });
 
-    return Service;
+    Service.RegistryService = Backbone.AssociatedModel.extend({
+        url: "/jolokia/exec/org.codice.ddf.registry:type=FederationAdminMBean/allRegistryInfo",
+            parse: function(data) {
+                return data;
+            }
+    });
 
+
+    Service.RegistryMetacards = Backbone.AssociatedModel.extend({
+        url: "/jolokia/exec/org.codice.ddf.registry:type=FederationAdminMBean/allRegistryMetacards",
+        parse: function(data) {
+            return data;
+        },
+        publishTo: function(idToPublishFrom, idsToPublishTo) {
+            var data = {
+                type: 'EXEC',
+                mbean: "org.codice.ddf.registry:type=FederationAdminMBean",
+                operation: "updatePublications",
+                arguments: [idToPublishFrom, idsToPublishTo]
+            };
+            data = JSON.stringify(data);
+            $.ajax({
+                type: 'POST',
+                url: "/jolokia/exec/org.codice.ddf.registry:type=FederationAdminMBean/updatePublications",
+                data: data
+            }).fail(function(error) {
+                console.log(error);
+            });
+        }
+    });
+    return Service;
 });

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/model/Source.js
@@ -14,210 +14,252 @@
  **/
 /*global define*/
 define([
-    'wreqr',
-    'js/model/Service.js',
-    'backbone',
-    'underscore',
-    'poller',
-    'js/model/Status.js',
-    'backboneassociation'
-],
-function (wreqr, Service, Backbone, _, poller, Status) {
-    var Source = {};
+        'wreqr',
+        'js/model/Service.js',
+        'backbone',
+        'underscore',
+        'poller',
+        'js/model/Status.js',
+        'backboneassociation'
+    ],
+    function(wreqr, Service, Backbone, _, poller, Status) {
+        var Source = {};
 
-    Source.ConfigurationList = Backbone.Collection.extend({
-        model: Service.Configuration
-    });
+        Source.ConfigurationList = Backbone.Collection.extend({
+            model: Service.Configuration
+        });
 
-    Source.Model = Backbone.Model.extend({
-        configUrl: "/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui",
-        idAttribute: 'name',
-        initialize: function() {
-            this.set('currentConfiguration', undefined);
-            this.set('disabledConfigurations', new Source.ConfigurationList());
-        },
-        addDisabledConfiguration: function(configuration) {
-            if(this.get("disabledConfigurations") && !this.get("disabledConfigurations").contains(configuration)) {
-                this.get("disabledConfigurations").add(configuration);
-            }
-        },
-        removeConfiguration: function(configuration) {
-            if(this.get("disabledConfigurations").contains(configuration)) {
-                this.stopListening(configuration);
-                this.get("disabledConfigurations").remove(configuration);
-            } else if (configuration === this.get("currentConfiguration")) {
-                this.stopListening(configuration);
-                this.set("currentConfiguration", undefined);
-            }
-        },
-        setCurrentConfiguration: function(configuration) {
-            // check to see if the source already has a 'currentConfiguration'
-            // if it does, make the currentConfiguration disabled and move it to the disabledConfiguration
-            // list
-            var currentConfig = this.get('currentConfiguration');
-            if (currentConfig) {
-                currentConfig.makeDisableCall();
-                this.addDisabledConfiguration(currentConfig);
-            }
-            this.set({currentConfiguration: configuration});
-
-            var pid = configuration.id;
-            var statusModel = new Status.Model(pid);
-            statusModel.on('sync', function() {
-                wreqr.vent.trigger('status:update-'+pid, statusModel);
-            });
-            
-            var options = {
-                delay: 30000
-            };
-
-            var statusPoller = poller.get(statusModel, options);
-            statusPoller.start();
-        },
-        hasConfiguration: function(configuration) {
-            var id = configuration.get('id');
-            var curConfig = this.get('currentConfiguration');
-            var hasConfig = false;
-
-            var found = this.get("disabledConfigurations").find(function(config) {
-                return config.get('fpid') === (id  + "_disabled");
-            });
-            if (_.isUndefined(found)) {
-                if (!_.isUndefined(curConfig)) {
-                    hasConfig = curConfig.get('fpid') === id;
+        Source.Model = Backbone.Model.extend({
+            configUrl: "/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui",
+            idAttribute: 'name',
+            initialize: function() {
+                this.set('currentConfiguration', undefined);
+                this.set('disabledConfigurations', new Source.ConfigurationList());
+            },
+            addDisabledConfiguration: function(configuration) {
+                if (this.get("disabledConfigurations") && !this.get("disabledConfigurations").contains(configuration)) {
+                    this.get("disabledConfigurations").add(configuration);
                 }
-            } else {
-                hasConfig = true;
-            }
-            return hasConfig;
-        },
-        initializeFromMSF: function(msf) {
-            this.set({"fpid":msf.get("id")});
-            this.set({"name":msf.get("name")});
-            this.initializeConfigurationFromMetatype(msf.get("metatype"));
-            this.configuration.set({"service.factoryPid": msf.get("id")});
-        },
-        initializeConfigurationFromMetatype: function(metatype) {
-            var src = this;
-            src.configuration = new Source.Configuration();
-            metatype.forEach(function(obj){
-                var id = obj.id;
-                var val = obj.defaultValue;
-                src.configuration.set(id, (val) ? val.toString() : null);
-            });
-        },
-        size: function() {
-            var ct = _.isUndefined(this.get('currentConfiguration')) ? 0 : 1;
-            return ct + this.get('disabledConfigurations').length;
-        }
-    });
+            },
+            removeConfiguration: function(configuration) {
+                if (this.get("disabledConfigurations").contains(configuration)) {
+                    this.stopListening(configuration);
+                    this.get("disabledConfigurations").remove(configuration);
+                } else if (configuration === this.get("currentConfiguration")) {
+                    this.stopListening(configuration);
+                    this.set("currentConfiguration", undefined);
+                }
+            },
+            setCurrentConfiguration: function(configuration) {
+                // check to see if the source already has a 'currentConfiguration'
+                // if it does, make the currentConfiguration disabled and move it to the disabledConfiguration
+                // list
+                var currentConfig = this.get('currentConfiguration');
+                if (currentConfig) {
+                    currentConfig.makeDisableCall();
+                    this.addDisabledConfiguration(currentConfig);
+                }
+                this.set({
+                    currentConfiguration: configuration
+                });
 
-    Source.Collection = Backbone.Collection.extend({
-        model: Source.Model,
-        addSource: function(configuration, enabled) {
-            var source;
-            var sourceId = configuration.get("properties").get('shortname');
-            if(!sourceId){
-                sourceId = configuration.get("properties").get('id');
-            }
-            if(this.get(sourceId)) {
-                source = this.get(sourceId);
-            } else {
-                source = new Source.Model({name: sourceId});
-                this.add(source);
-            }
-            if(enabled) {
-                source.setCurrentConfiguration(configuration);
-            } else {
-                source.addDisabledConfiguration(configuration);
-            }
-            source.trigger('change');
-        },
-        removeSource: function(source) {
-            this.stopListening(source);
-            this.remove(source);
-        },
-        comparator: function(model) {
-            var str = model.get('name') || '';
-            return str.toLowerCase();
-        }
-    });
+                var pid = configuration.id;
+                var statusModel = new Status.Model(pid);
+                statusModel.on('sync', function() {
+                    wreqr.vent.trigger('status:update-' + pid, statusModel);
+                });
 
-    Source.Response = Backbone.Model.extend({
-        initialize: function(options) {
-            if(options.model) {
-                this.model = options.model;
-                var collection = new Source.Collection();
-                this.set({collection: collection});
-                this.listenTo(this.model, 'change', this.parseServiceModel);
-            }
-        },
-        parseServiceModel: function() {
-            var resModel = this;
-            var collection = resModel.get('collection');
-            collection.reset();
-            if(this.model.get("value")) {
-                this.model.get("value").each(function(service) {
-                    if(!_.isEmpty(service.get("configurations"))) {
-                        service.get("configurations").each(function(configuration) {
-                            var cfgService = configuration.get('service');
-                            if(configuration.get('id') && (resModel.isSourceName(configuration.get('fpid')) || 
-                                    (cfgService && resModel.isSourceName(cfgService.get('name'))))){
-                                if(configuration.get('fpid').indexOf('_disabled') === -1){
-                                    collection.addSource(configuration, true);
-                                } else {
-                                    collection.addSource(configuration, false);
-                                }
-                            }
-                        });
+                var options = {
+                    delay: 30000
+                };
+
+                var statusPoller = poller.get(statusModel, options);
+                statusPoller.start();
+            },
+            hasConfiguration: function(configuration) {
+                var id = configuration.get('id');
+                var curConfig = this.get('currentConfiguration');
+                var hasConfig = false;
+
+                var found = this.get("disabledConfigurations").find(function(config) {
+                    return config.get('fpid') === (id + "_disabled");
+                });
+                if (_.isUndefined(found)) {
+                    if (!_.isUndefined(curConfig)) {
+                        hasConfig = curConfig.get('fpid') === id;
                     }
-                });
-            }
-            collection.sort();
-            collection.trigger('reset');
-        },
-        getSourceMetatypes: function() {
-            var resModel = this;
-            var metatypes = [];
-            if(resModel.model.get('value')) {
-                resModel.model.get('value').each(function(service) {
-                var id = service.get('id');
-                var name = service.get('name');
-                if (this.isSourceName(id) || this.isSourceName(name)) {
-                    metatypes.push(service);
+                } else {
+                    hasConfig = true;
                 }
+                return hasConfig;
+            },
+            initializeFromMSF: function(msf) {
+                this.set({
+                    "fpid": msf.get("id")
                 });
-            }
-            return metatypes;
-        },
-        isSourceName: function(val) {
-            return val && val.indexOf('Source') !== -1;
-        },
-        /**
-         * Returns a SourceModel that has all available source type configurations. Each source type configuration will be added as a 
-         * disabledConfiguration and returned as part of the model. If an initialModel is presented, it will be modified to include any
-         * missing configurations as part of its disabledConfigurations.
-         */
-        getSourceModelWithServices: function(initialModel) {
-            var resModel = this;
-            var serviceCollection = resModel.model.get('value');
-            if (!initialModel) {
-                initialModel = new Source.Model();
-            }
-            
-            if(serviceCollection) {
-                serviceCollection.each(function(service) {
-                    var config = new Service.Configuration({service: service});
-                    config.set('fpid', config.get('fpid') + '_disabled');
-                    initialModel.addDisabledConfiguration(config);
+                this.set({
+                    "name": msf.get("name")
                 });
+                this.initializeConfigurationFromMetatype(msf.get("metatype"));
+                this.configuration.set({
+                    "service.factoryPid": msf.get("id")
+                });
+            },
+            initializeConfigurationFromMetatype: function(metatype) {
+                var src = this;
+                src.configuration = new Source.Configuration();
+                metatype.forEach(function(obj) {
+                    var id = obj.id;
+                    var val = obj.defaultValue;
+                    src.configuration.set(id, (val) ? val.toString() : null);
+                });
+            },
+            size: function() {
+                var ct = _.isUndefined(this.get('currentConfiguration')) ? 0 : 1;
+                return ct + this.get('disabledConfigurations').length;
             }
-            return initialModel;
-        },
-        isSourceConfiguration: function(configuration) {
-            return (configuration.get('fpid') && configuration.get('id') && configuration.get('fpid').indexOf('Source') !== -1);
-        }
-    });
-    return Source;
+        });
 
-});
+        Source.Collection = Backbone.Collection.extend({
+            model: Source.Model,
+            addSource: function(configuration, enabled) {
+                var source;
+                var sourceId = configuration.get("properties").get('shortname');
+                if (!sourceId) {
+                    sourceId = configuration.get("properties").get('id');
+                }
+                if (this.get(sourceId)) {
+                    source = this.get(sourceId);
+                } else {
+                    source = new Source.Model({
+                        name: sourceId
+                    });
+                    this.add(source);
+                }
+                if (enabled) {
+                    source.setCurrentConfiguration(configuration);
+                } else {
+                    source.addDisabledConfiguration(configuration);
+                }
+                source.trigger('change');
+            },
+            removeSource: function(source) {
+                this.stopListening(source);
+                this.remove(source);
+            },
+            comparator: function(model) {
+                var str = model.get('name') || '';
+                return str.toLowerCase();
+            }
+        });
+
+        Source.Response = Backbone.Model.extend({
+            initialize: function(options) {
+                if (options.model) {
+                    this.model = options.model;
+                    var collection = new Source.Collection();
+                    this.set({
+                        collection: collection
+                    });
+                    this.listenTo(this.model, 'change', this.parseServiceModel);
+                }
+            },
+            parseServiceModel: function() {
+                var resModel = this;
+                var collection = resModel.get('collection');
+                collection.reset();
+                if (this.model.get("value")) {
+                    this.model.get("value").each(function(service) {
+                        if (!_.isEmpty(service.get("configurations"))) {
+                            service.get("configurations").each(function(configuration) {
+                                var cfgService = configuration.get('service');
+                                if (configuration.get('id') && (resModel.isSourceName(configuration.get('fpid')) ||
+                                        (cfgService && resModel.isSourceName(cfgService.get('name'))))) {
+                                    if (configuration.get('fpid').indexOf('_disabled') === -1) {
+                                        collection.addSource(configuration, true);
+                                    } else {
+                                        collection.addSource(configuration, false);
+                                    }
+                                }
+                            });
+                        }
+                    });
+                }
+                collection.sort();
+                collection.trigger('reset');
+            },
+            getSourceMetatypes: function() {
+                var resModel = this;
+                var metatypes = [];
+                if (resModel.model.get('value')) {
+                    resModel.model.get('value').each(function(service) {
+                        var id = service.get('id');
+                        var name = service.get('name');
+                        if (this.isSourceName(id) || this.isSourceName(name)) {
+                            metatypes.push(service);
+                        }
+                    });
+                }
+                return metatypes;
+            },
+            isSourceName: function(val) {
+                return val && val.indexOf('Source') !== -1;
+            },
+            /**
+             * Returns a SourceModel that has all available source type configurations. Each source type configuration will be added as a
+             * disabledConfiguration and returned as part of the model. If an initialModel is presented, it will be modified to include any
+             * missing configurations as part of its disabledConfigurations.
+             */
+            getSourceModelWithServices: function(initialModel) {
+                var resModel = this;
+                var serviceCollection = resModel.model.get('value');
+                if (!initialModel) {
+                    initialModel = new Source.Model();
+                }
+                var registryId = this.getRegistryIdFromConfigurations(initialModel);
+                if (serviceCollection) {
+                    serviceCollection.each(function(service) {
+                        var config = new Service.Configuration({
+                            service: service
+                        });
+                        config.set('fpid', config.get('fpid') + '_disabled');
+                        config.get('properties').set('registry-id', registryId);
+                        initialModel.addDisabledConfiguration(config);
+                    });
+                }
+                initialModel.set('registryId', registryId);
+                return initialModel;
+            },
+            /**
+             * Returns the registry-id that corresponds to the given model.
+             */
+            getRegistryIdFromConfigurations: function(model) {
+                var configuration = model.get('currentConfiguration');
+                // If no current configuration or the configuration does not have a registry-id, then the current
+                // Active Binding is disabled. Search through the disabled configurations to find the one that
+                // contains the models registry-id.
+                if (!configuration || !configuration.get('properties').get('registry-id')) {
+                    var disabledConfigWithRegistryId = model.get('disabledConfigurations').models.find(function(disabledConfig) {
+                        if (disabledConfig.get('properties').id) {
+                            if (disabledConfig.get('properties').get('registry-id')) {
+                                return true;
+                            }
+                        }
+                    });
+                    if (disabledConfigWithRegistryId) {
+                        return disabledConfigWithRegistryId.get('properties').get('registry-id');
+                    }
+                }
+                if (!configuration && !_.isEmpty(model.get('disableConfigurations'))) {
+                    configuration = model.get('disabledConfigurations')[0];
+                }
+                if (configuration) {
+                    return configuration.get('properties').get('registry-id');
+                }
+            },
+            isSourceConfiguration: function(configuration) {
+                return (configuration.get('fpid') && configuration.get('id') && configuration.get('fpid').indexOf('Source') !== -1);
+            }
+        });
+        return Source;
+    });

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/module.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/module.js
@@ -12,53 +12,65 @@
  * <http://www.gnu.org/licenses/lgpl.html>.
  *
  **/
-
 /*global define*/
 define([
-    'wreqr',
-    'js/application',
-    'js/view/Source.view.js',
-    'poller',
-    'js/model/Source.js',
-    'js/model/Status.js',
-    'js/model/Service.js'
-],
-function(wreqr, Application, SourceView, poller, Source, Status, Service) {
+        'wreqr',
+        'js/application',
+        'js/view/Source.view.js',
+        'poller',
+        'js/model/Source.js',
+        'js/model/Status.js',
+        'js/model/Service.js'
+    ],
+    function(wreqr, Application, SourceView, poller, Source, Status, Service) {
 
-    Application.App.module('Sources', function(SourceModule, App, Backbone, Marionette)  {
+        Application.App.module('Sources', function(SourceModule, App, Backbone, Marionette) {
 
-        var serviceModel = new Service.Response();
-        serviceModel.fetch();
+            var serviceModel = new Service.Response();
+            serviceModel.fetch();
 
-        var sourceResponse = new Source.Response({model: serviceModel});
+            var registryMetacards = new Service.RegistryMetacards();
+            registryMetacards.fetch();
 
-        var sourcePage = new SourceView.SourcePage({model: sourceResponse});
+            var registryService = new Service.RegistryService();
+            registryService.fetch();
 
-        // Define a controller to run this module
-        // --------------------------------------
+            serviceModel.registryMetacards = registryMetacards;
+            serviceModel.registryService = registryService;
 
-        var Controller = Marionette.Controller.extend({
-
-            initialize: function(options){
-                this.region = options.region;
-            },
-
-            show: function(){
-                this.region.show(sourcePage);
-            }
-
-        });
-
-        // Initialize this module when the app starts
-        // ------------------------------------------
-
-        SourceModule.addInitializer(function(){
-            SourceModule.contentController = new Controller({
-                region: App.mainRegion
+            var sourceResponse = new Source.Response({
+                model: serviceModel
             });
-            SourceModule.contentController.show();
+
+            var sourcePage = new SourceView.SourcePage({
+                model: sourceResponse
+            });
+
+            // Define a controller to run this module
+            // --------------------------------------
+
+            var Controller = Marionette.Controller.extend({
+
+                initialize: function(options) {
+                    this.region = options.region;
+                },
+
+                show: function() {
+                    this.region.show(sourcePage);
+                }
+
+            });
+
+            // Initialize this module when the app starts
+            // ------------------------------------------
+
+            SourceModule.addInitializer(function() {
+                SourceModule.contentController = new Controller({
+                    region: App.mainRegion
+                });
+                SourceModule.contentController.show();
+            });
+
+
         });
-
-
     });
-});

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Accordion.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Accordion.view.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define([
+    'marionette',
+    'icanhaz',
+    'js/view/Accordion.view.js',
+    'text!templates/accordion.hbs'
+], function(Marionette, ich, AccordionView, accordion) {
+    if (!ich.accordion) {
+        ich.addTemplate('accordion', accordion);
+    }
+
+    AccordionView = Marionette.Layout.extend({
+        template: 'accordion',
+        tagName: 'div',
+        regions: {
+            accordionContent: '.accordion-content'
+        },
+        events: {
+            'click .accordion-title': 'toggle'
+        },
+        toggle: function() {
+            this.$el.find('.accordion-content').toggleClass('show');
+            this.$el.find(".fa-chevron-down, .fa-chevron-up").toggleClass('fa-chevron-down fa-chevron-up');
+        },
+        onRender: function() {
+            this.accordionContent.show(this.model.get('contentView'));
+        }
+    });
+    return AccordionView;
+});

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/AccordionCollectionView.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/AccordionCollectionView.js
@@ -14,25 +14,16 @@
  **/
 /*global define*/
 define([
-    'text!templates/emptyView.handlebars',
-    'marionette',
-    'icanhaz'
-], function(emptyViewTemplate, Marionette, ich) {
+    'js/view/Accordion.view.js',
+    'marionette'
+], function(AccordionView, Marionette) {
 
-    if (!ich.emptyViewTemplate) {
-        ich.addTemplate('emptyViewTemplate', emptyViewTemplate);
-    }
 
-    var EmptyView = {};
+    var AccordionCollectionView = {};
 
-    EmptyView.sources = Marionette.ItemView.extend({
-        template: 'emptyViewTemplate',
-        serializeData: function() {
-            return {
-                message: "There are no sources configured."
-            };
-        }
+    AccordionCollectionView = Marionette.CollectionView.extend({
+        itemView: AccordionView
     });
 
-    return EmptyView;
+    return AccordionCollectionView;
 });

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ConfigurationEdit.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/ConfigurationEdit.view.js
@@ -25,25 +25,25 @@ define([
     'text!templates/configuration/textTypeListHeader.handlebars',
     'text!templates/configuration/textTypeList.handlebars',
     'text!templates/configuration/checkboxType.handlebars'
-    ], function (Marionette, ich, _, Backbone, wreqr, configurationEdit, configurationItem, textTypeListHeader, textTypeList, checkboxTemplate ) {
+], function(Marionette, ich, _, Backbone, wreqr, configurationEdit, configurationItem, textTypeListHeader, textTypeList, checkboxTypeTemplate) {
 
     var ConfigurationEditView = {};
 
 
-    if(!ich['configuration.configurationItem']) {
+    if (!ich['configuration.configurationItem']) {
         ich.addTemplate('configuration.configurationItem', configurationItem);
     }
-    if(!ich['configuration.configurationEdit']) {
+    if (!ich['configuration.configurationEdit']) {
         ich.addTemplate('configuration.configurationEdit', configurationEdit);
     }
-    if(!ich['configuration.textTypeListHeader']) {
+    if (!ich['configuration.textTypeListHeader']) {
         ich.addTemplate('configuration.textTypeListHeader', textTypeListHeader);
     }
-    if(!ich['configuration.textTypeList']) {
+    if (!ich['configuration.textTypeList']) {
         ich.addTemplate('configuration.textTypeList', textTypeList);
     }
-    if(!ich['configuration.checkboxTypeTemplate']) {
-        ich.addPartial('configuration.checkboxTypeTemplate', checkboxTemplate);
+    if (!ich['configuration.checkboxTypeTemplate']) {
+        ich.addPartial('configuration.checkboxTypeTemplate', checkboxTypeTemplate);
     }
 
     ConfigurationEditView.ConfigurationMultiValuedEntry = Marionette.ItemView.extend({
@@ -98,19 +98,19 @@ define([
         },
         updateValues: function() {
             var csvVal, view = this;
-            if(this.configuration.get('properties') && this.configuration.get('properties').get(this.model.get('id'))) {
+            if (this.configuration.get('properties') && this.configuration.get('properties').get(this.model.get('id'))) {
                 csvVal = this.configuration.get('properties').get(this.model.get('id'));
             } else {
                 csvVal = this.model.get('defaultValue');
             }
             this.collectionArray.reset();
-            if(csvVal && csvVal !== '') {
-                if(_.isArray(csvVal)) {
-                    _.each(csvVal, function (item) {
+            if (csvVal && csvVal !== '') {
+                if (_.isArray(csvVal)) {
+                    _.each(csvVal, function(item) {
                         view.addItem(item);
                     });
                 } else {
-                    _.each(csvVal.split(/[,]+/), function (item) {
+                    _.each(csvVal.split(/[,]+/), function(item) {
                         view.addItem(item);
                     });
                 }
@@ -121,7 +121,12 @@ define([
             _.each(this.collectionArray.models, function(model) {
                 values.push(model.get('value'));
             });
-            this.configuration.get('properties').set(this.model.get('id'), values);
+            if (this.configuration.get('configurations')) {
+                this.configuration.get('configurations').models[0].get('properties').set(this.model.get('id'), values);
+            } else {
+                this.configuration.get('properties').set(this.model.get('id'), values);
+            }
+
         },
         onRender: function() {
             this.listItems.show(new ConfigurationEditView.ConfigurationMultiValueCollection({
@@ -131,7 +136,9 @@ define([
             this.updateValues();
         },
         addItem: function(value) {
-            this.collectionArray.add(new Backbone.Model({value: value}));
+            this.collectionArray.add(new Backbone.Model({
+                value: value
+            }));
         },
         /**
          * Creates a new text field for the properties collection.
@@ -142,7 +149,23 @@ define([
     });
 
     ConfigurationEditView.ConfigurationItem = Marionette.ItemView.extend({
-        template: 'configuration.configurationItem'
+        template: 'configuration.configurationItem',
+        events: {
+            'change input': 'updateModel'
+        },
+        /**
+         * Save all values properties into the sourceModal
+         */
+        serializeData: function() {
+            var value = this.options.configuration.get('properties').get(this.model.get('id'));
+            return _.extend(this.model.toJSON(), {
+                defaultValue: value || this.model.get('defaultValue')
+            });
+        },
+        updateModel: function(e) {
+            var config = this.options.configuration;
+            config.get('properties').set(this.model.get('id'), e.target.value);
+        }
     });
 
     ConfigurationEditView.ConfigurationCollection = Marionette.CollectionView.extend({
@@ -154,23 +177,30 @@ define([
         onRender: function() {
             this.setupPopOvers();
         },
-        buildItemView: function(item, ItemViewType, itemViewOptions){
+        buildItemView: function(item, ItemViewType, itemViewOptions) {
             var view;
             var configuration = this.options.configuration;
             this.collection.forEach(function(property) {
-                if(item.get('id') === property.id) {
-                    if(property.description) {
-                        item.set({ 'description': property.description });
+                if (item.get('id') === property.id) {
+                    if (property.description) {
+                        item.set({
+                            'description': property.description
+                        });
                     }
-                    if(property.note) {
-                        item.set({ 'note': property.note});
+                    if (property.note) {
+                        item.set({
+                            'note': property.note
+                        });
                     }
-                    var options = _.extend({model: item, configuration: configuration}, itemViewOptions);
+                    var options = _.extend({
+                        model: item,
+                        configuration: configuration
+                    }, itemViewOptions);
 
                     view = new ItemViewType(options);
                 }
             });
-            if(view) {
+            if (view) {
                 return view;
             }
             return new Marionette.ItemView();
@@ -181,8 +211,8 @@ define([
         setupPopOvers: function() {
             var view = this;
             this.service.get('metatype').forEach(function(each) {
-                if(!_.isUndefined(each.get("description"))) {
-                   var options,
+                if (!_.isUndefined(each.get("description"))) {
+                    var options,
                         selector = ".description[data-title='" + each.id + "']";
                     options = {
                         title: each.get("name"),
@@ -193,8 +223,8 @@ define([
                 }
             });
         },
-        getItemView: function( item ) {
-            if(item.get('cardinality') > 0 || item.get('cardinality') < 0) {
+        getItemView: function(item) {
+            if (item.get('cardinality') > 0 || item.get('cardinality') < 0) {
                 return ConfigurationEditView.ConfigurationMultiValuedItem;
             } else {
                 return ConfigurationEditView.ConfigurationItem;

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Organization.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Organization.view.js
@@ -14,25 +14,20 @@
  **/
 /*global define*/
 define([
-    'text!templates/emptyView.handlebars',
+    'icanhaz',
     'marionette',
-    'icanhaz'
-], function(emptyViewTemplate, Marionette, ich) {
+    'text!templates/sourceOrganization.hbs'
+], function(ich, Marionette, sourceOrganization) {
 
-    if (!ich.emptyViewTemplate) {
-        ich.addTemplate('emptyViewTemplate', emptyViewTemplate);
+    if (!ich.sourceOrganization) {
+        ich.addTemplate('sourceOrganization', sourceOrganization);
     }
 
-    var EmptyView = {};
+    var OrganizationView = {};
 
-    EmptyView.sources = Marionette.ItemView.extend({
-        template: 'emptyViewTemplate',
-        serializeData: function() {
-            return {
-                message: "There are no sources configured."
-            };
-        }
+    OrganizationView = Marionette.ItemView.extend({
+        template: 'sourceOrganization'
     });
 
-    return EmptyView;
+    return OrganizationView;
 });

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/js/view/Source.view.js
@@ -14,332 +14,344 @@
  **/
 /*global define*/
 define([
-    'icanhaz',
-    'marionette',
-    'underscore',
-    'jquery',
-    'q',
-    'js/view/ModalSource.view.js',
-    'js/view/EmptyView.js',
-    'js/model/Service.js',
-    'js/model/Status.js',
-    'wreqr',
-    'js/view/Utils.js',
-    'text!templates/deleteModal.handlebars',
-    'text!templates/deleteSource.handlebars',
-    'text!templates/sourcePage.handlebars',
-    'text!templates/sourceList.handlebars',
-    'text!templates/sourceRow.handlebars'
-],
-function (ich,Marionette,_,$,Q,ModalSource,EmptyView,Service,Status,wreqr,Utils,deleteModal,deleteSource,sourcePage,sourceList,sourceRow) {
+        'icanhaz',
+        'marionette',
+        'underscore',
+        'jquery',
+        'q',
+        'js/view/ModalSource.view.js',
+        'js/view/EmptyView.js',
+        'js/model/Service.js',
+        'js/model/Status.js',
+        'wreqr',
+        'js/view/Utils.js',
+        'text!templates/deleteModal.handlebars',
+        'text!templates/deleteSource.handlebars',
+        'text!templates/sourcePage.handlebars',
+        'text!templates/sourceList.handlebars',
+        'text!templates/sourceRow.handlebars'
+    ],
+    function(ich, Marionette, _, $, Q, ModalSource, EmptyView, Service, Status, wreqr, Utils, deleteModal, deleteSource, sourcePage, sourceList, sourceRow) {
 
-    var SourceView = {};
+        var SourceView = {};
 
-    ich.addTemplate('deleteModal', deleteModal);
-    ich.addTemplate('deleteSource', deleteSource);
-    ich.addTemplate('sourcePage', sourcePage);
-	ich.addTemplate('sourceList', sourceList);
-	ich.addTemplate('sourceRow', sourceRow);
+        ich.addTemplate('deleteModal', deleteModal);
+        ich.addTemplate('deleteSource', deleteSource);
+        ich.addTemplate('sourcePage', sourcePage);
+        ich.addTemplate('sourceList', sourceList);
+        ich.addTemplate('sourceRow', sourceRow);
 
-	SourceView.SourceRow = Marionette.Layout.extend({
-        template: "sourceRow",
-        tagName: "tr",
-        className: "highlight-on-hover",
-        regions: {
-            editModal: '.modal-container'
-        },
-        events: {
-            'change .configurationSelect' : 'changeConfiguration',
-            'click .configurationSelect' : 'handleSelector',
-            'click td' : 'editSource'
-        },
-        initialize: function(){
-            _.bindAll(this);
-            this.listenTo(this.model, 'change', this.render);
+        SourceView.SourceRow = Marionette.Layout.extend({
+            template: "sourceRow",
+            tagName: "tr",
+            className: "highlight-on-hover",
+            regions: {
+                editModal: '.modal-container'
+            },
+            events: {
+                'change .configurationSelect': 'changeConfiguration',
+                'click .configurationSelect': 'handleSelector',
+                'click td': 'editSource'
+            },
+            initialize: function() {
+                _.bindAll(this);
+                this.listenTo(this.model, 'change', this.render);
 
-            if (this.model.has('currentConfiguration')) {
-                this.listenTo(wreqr.vent, 'status:update-'+ this.model.attributes.currentConfiguration.id, this.updateStatus);
-            }
-
-        },
-        serializeData: function(){
-            var data = {};
-
-            if(this.model && this.model.has('currentConfiguration')){
-                data.currentConfiguration = this.model.get('currentConfiguration').toJSON();
-            }
-            if(this.model && this.model.has('disabledConfigurations')){
-                data.disabledConfigurations = this.model.get('disabledConfigurations').toJSON();
-            }
-            data.available = this.model.get('available');
-            data.name = this.model.get('name');
-
-            return data;
-        },
-        handleSelector: function(evt) {
-            evt.stopPropagation();
-        },
-        editSource: function(evt) {
-            evt.stopPropagation();
-            var service = this.model;
-            wreqr.vent.trigger('editSource', service);
-        },
-        changeConfiguration: function(evt) {
-            var model = this.model;
-            var currentConfig = model.get('currentConfiguration');
-            var disabledConfigs = model.get('disabledConfigurations');
-            var $select = $(evt.currentTarget);
-            var optionSelected = $select.find("option:selected");
-            var valueSelected = optionSelected.val();
-            var cfgToDisable;
-            var deferred = $.Deferred().resolve();
-
-            if (valueSelected === 'Disabled') {
-                cfgToDisable = currentConfig;
-                if (!_.isUndefined(cfgToDisable)) {
-                    deferred = deferred.then(function() {
-                        return cfgToDisable.makeDisableCall();
-                    });
+                if (this.model.has('currentConfiguration')) {
+                    this.listenTo(wreqr.vent, 'status:update-' + this.model.attributes.currentConfiguration.id, this.updateStatus);
                 }
-            } else {
-                var cfgToEnable = disabledConfigs.find(function(cfg) {
-                    return valueSelected + "_disabled" === cfg.get('fpid');
-                });
 
-                if (cfgToEnable) {
+            },
+            serializeData: function() {
+                var data = {};
+
+                if (this.model && this.model.has('currentConfiguration')) {
+                    data.currentConfiguration = this.model.get('currentConfiguration').toJSON();
+                } else {
+                    data.currentConfiguration = undefined;
+                }
+                if (this.model && this.model.has('disabledConfigurations')) {
+                    data.disabledConfigurations = this.model.get('disabledConfigurations').toJSON();
+                }
+                data.available = this.model.get('available');
+                data.name = this.model.get('name');
+
+                return data;
+            },
+            handleSelector: function(evt) {
+                evt.stopPropagation();
+            },
+            editSource: function(evt) {
+                evt.stopPropagation();
+                var service = this.model;
+                wreqr.vent.trigger('editSource', service);
+            },
+            changeConfiguration: function(evt) {
+                var model = this.model;
+                var currentConfig = model.get('currentConfiguration');
+                var disabledConfigs = model.get('disabledConfigurations');
+                var $select = $(evt.currentTarget);
+                var optionSelected = $select.find("option:selected");
+                var valueSelected = optionSelected.val();
+                var cfgToDisable;
+                var deferred = $.Deferred().resolve();
+
+                if (valueSelected === 'Disabled') {
                     cfgToDisable = currentConfig;
-
                     if (!_.isUndefined(cfgToDisable)) {
                         deferred = deferred.then(function() {
                             return cfgToDisable.makeDisableCall();
                         });
                     }
-
-                    deferred = deferred.then(function() {
-                        return cfgToEnable.makeEnableCall();
+                } else {
+                    var cfgToEnable = disabledConfigs.find(function(cfg) {
+                        return valueSelected + "_disabled" === cfg.get('fpid');
                     });
-                }
-            }
-            deferred.then(function() {
-                wreqr.vent.trigger('refreshSources');
-            });
-            evt.stopPropagation();
-        },
-        updateStatus: function(status) {
-            this.model.set('available', status.get('value'));
-            this.render();
-        }
-    });
 
-    SourceView.SourceTable = Marionette.CompositeView.extend({
-        template: 'sourceList',
-        itemView: SourceView.SourceRow,
-        emptyView: EmptyView.sources,
-        itemViewContainer: 'tbody'
-    });
+                    if (cfgToEnable) {
+                        cfgToDisable = currentConfig;
 
-    SourceView.SourcePage = Marionette.Layout.extend({
-        template: 'sourcePage',
-        events: {
-            'click .removeSourceLink' : 'removeSource',
-            'click .addSourceLink' : 'addSource'
-        },
-        initialize: function(){
-            _.bindAll(this);
-            this.listenTo(wreqr.vent, 'editSource', this.editSource);
-            this.listenTo(wreqr.vent, 'refreshSources', this.refreshSources);
-            this.listenTo(wreqr.vent, 'changeConfiguration', this.changeConfiguration);
-            new SourceView.ModalController({
-                application: this
-            });
-        },
-        regions: {
-            collectionRegion: '#sourcesRegion',
-            sourcesModal: '#sources-modal'
-        },
-        onShow: function(){
-            this.refreshButton = Utils.refreshButton('.refreshButton', this.refreshSources);
-        },
-        onDestroy: function() {
-            this.refreshButton.close();
-        },
-        onRender: function() {
-            var collection = this.model.get('collection');
-            this.collectionRegion.show(new SourceView.SourceTable({ model: this.model, collection: collection }));
-        },
-        refreshSources: function() {
-            var view = this;
-            view.model.get('model').clear();
-
-            view.model.get('model').fetch({
-                success: function(){
-                    view.model.get('collection').sort();
-                    view.model.get('collection').trigger('reset');
-                    view.refreshButton.done();
-                }
-            });
-        },
-        editSource: function(service) {
-            wreqr.vent.trigger("showModal",
-                new ModalSource.View({
-                    model: this.model.getSourceModelWithServices(service),
-                    source: this.model,
-                    mode: 'edit'
-                })
-            );
-        },
-        removeSource: function() {
-            if(this.model) {
-                wreqr.vent.trigger("showModal",
-                    new SourceView.DeleteModal({
-                        model: this.model,
-                        collection: this.model.get('collection')
-                    })
-                );
-            }
-        },
-        addSource: function() {
-            if(this.model) {
-                wreqr.vent.trigger("showModal",
-                    new ModalSource.View({
-                        model: this.model.getSourceModelWithServices(),
-                        source: this.model,
-                        mode: 'add'
-                    })
-                );
-            }
-        }
-    });
-
-    SourceView.ModalController = Marionette.Controller.extend({
-        initialize: function (options) {
-            this.application = options.application;
-            this.listenTo(wreqr.vent, "showModal", this.showModal);
-        },
-        showModal: function(modalView) {
-            // Global div for workaround with iframe resize and modals
-            var region = this.application.getRegion('sourcesModal');
-            var collectionRegion = this.application.getRegion('collectionRegion');
-            var iFrameModalDOM = $('#IframeModalDOM');
-            modalView.$el.on('hidden.bs.modal', function () {
-                iFrameModalDOM.hide();
-            });
-            modalView.$el.on('shown.bs.modal', function () {
-                var extraHeight = modalView.el.firstChild.clientHeight - collectionRegion.$el.height();
-                if(extraHeight > 0) {
-                    iFrameModalDOM.height(extraHeight);
-                    iFrameModalDOM.show();
-                }
-            });
-            region.show(modalView);
-            region.currentView.$el.modal();
-        }
-    });
-
-    SourceView.DeleteItem = Marionette.ItemView.extend({
-        template: "deleteSource"
-    });
-
-    SourceView.DeleteModal  = Marionette.CompositeView.extend({
-        template: 'deleteModal',
-        className: 'modal',
-        itemView: SourceView.DeleteItem,
-        itemViewContainer: '.modal-body',
-        events: {
-            'click .submit-button' : 'deleteSources',
-            'click .deleteSource' : 'toggleChecks',
-            'click .selectSourceDelete' : 'toggleChecks'
-        },
-        toggleChecks: function(e) {
-            var view = this;
-            var checked = e.target.checked;
-            // Loop through all the source views available to get the one relevant to the click.
-            // We don't want to go deleting/checking the wrong source/service.
-            var sourceView = view.children.find(function (childView) {
-                return (childView.model.get("name") === e.target.value);
-            });
-
-            // Check to see if user clicked the source (top-level) checkbox or a service checkbox.
-            if (e.target.className === "deleteSource") {
-                // If user clicked source checkbox, toggle all services underneath to match it.
-                sourceView.$(".selectSourceDelete").each(function() {
-                    this.checked = checked;
-                });
-            } else if (e.target.className === "selectSourceDelete") {
-                // If user deselected a service checkbox, make sure to also deselect the source checkbox.
-                if (!checked) {
-                    sourceView.$(".deleteSource")[0].checked = false;
-
-                // Check to see if a user has manually selected all the services in a source, if they have,
-                // also select the source checkbox.
-                } else if (checked) {
-                    var allChecked = true;
-                    sourceView.$(".selectSourceDelete").each(function() {
-                        allChecked = allChecked && this.checked;
-                    });
-                    sourceView.$(".deleteSource")[0].checked = allChecked;
-                }
-            }
-
-        },
-        deleteSources: function() {
-            var view = this;
-            var toDelete = [];
-            view.collection.each(function (item) {
-                var currentConfig = item.get('currentConfiguration');
-                var disableConfigs = item.get('disabledConfigurations');
-                view.$(".selectSourceDelete").each(function(index, content) {
-                    if (content.checked) {
-
-                        var id = currentConfig ? currentConfig.get('id') : null;
-                        if (id === content.id) {
-                            toDelete.push(view.createDeletePromise(item, currentConfig));
-                        } else if (disableConfigs) {
-                            disableConfigs.each(function (disabledConfig) {
-                                if (disabledConfig.get('id') === content.id) {
-                                    toDelete.push(view.createDeletePromise(item, disabledConfig));
-                                }
+                        if (!_.isUndefined(cfgToDisable)) {
+                            deferred = deferred.then(function() {
+                                return cfgToDisable.makeDisableCall();
                             });
                         }
+
+                        deferred = deferred.then(function() {
+                            return cfgToEnable.makeEnableCall();
+                        });
+                    }
+                }
+                deferred.then(function() {
+                    wreqr.vent.trigger('refreshSources');
+                });
+                evt.stopPropagation();
+            },
+            updateStatus: function(status) {
+                this.model.set('available', status.get('value'));
+                this.render();
+            }
+        });
+
+        SourceView.SourceTable = Marionette.CompositeView.extend({
+            template: 'sourceList',
+            itemView: SourceView.SourceRow,
+            emptyView: EmptyView.sources,
+            itemViewContainer: 'tbody'
+        });
+
+        SourceView.SourcePage = Marionette.Layout.extend({
+            template: 'sourcePage',
+            events: {
+                'click .removeSourceLink': 'removeSource',
+                'click .addSourceLink': 'addSource'
+            },
+            initialize: function() {
+                _.bindAll(this);
+                this.listenTo(wreqr.vent, 'editSource', this.editSource);
+                this.listenTo(wreqr.vent, 'refreshSources', this.refreshSources);
+                this.listenTo(wreqr.vent, 'changeConfiguration', this.changeConfiguration);
+                new SourceView.ModalController({
+                    application: this
+                });
+            },
+            regions: {
+                collectionRegion: '#sourcesRegion',
+                sourcesModal: '#sources-modal'
+            },
+            onShow: function() {
+                this.refreshButton = Utils.refreshButton('.refreshButton', this.refreshSources);
+            },
+            onDestroy: function() {
+                this.refreshButton.close();
+            },
+            onRender: function() {
+                var collection = this.model.get('collection');
+                this.collectionRegion.show(new SourceView.SourceTable({
+                    model: this.model,
+                    collection: collection
+                }));
+            },
+            refreshSources: function() {
+                var view = this;
+                view.model.get('model').clear();
+                view.model.get('model').fetch({
+                    success: function() {
+                        view.model.get('model').registryService.fetch({
+                            success: function() {
+                                view.model.get('model').registryMetacards.fetch({
+                                    success: function() {
+                                        view.model.get('collection').sort();
+                                        view.model.get('collection').trigger('reset');
+                                        view.refreshButton.done();
+                                    }
+                                });
+                            }
+                        });
                     }
                 });
-            });
+            },
+            editSource: function(service) {
+                wreqr.vent.trigger("showModal",
+                    new ModalSource.View({
+                        model: this.model.getSourceModelWithServices(service),
+                        source: this.model,
+                        mode: 'edit'
+                    })
+                );
+            },
+            removeSource: function() {
+                if (this.model) {
+                    wreqr.vent.trigger("showModal",
+                        new SourceView.DeleteModal({
+                            model: this.model,
+                            collection: this.model.get('collection')
+                        })
+                    );
+                }
+            },
+            addSource: function() {
+                if (this.model) {
+                    wreqr.vent.trigger("showModal",
+                        new ModalSource.View({
+                            model: this.model.getSourceModelWithServices(),
+                            source: this.model,
+                            mode: 'add'
+                        })
+                    );
+                }
+            }
+        });
 
-            //remove queued source configurations and entire source config if necessary
-            if (toDelete.length > 0) {
-                //remove all selected configurations from the current item
-                Q.all(toDelete).then(function(results) {
-                    _.each(results, function(result) {
-                        var item = result.source;
-                        if (item.size() <= 0) {
-                            //if no type configurations, delete the entire source.
-                            view.model.get('collection').removeSource(item);
-                            view.model.get('model').get('value').remove(item);
+        SourceView.ModalController = Marionette.Controller.extend({
+            initialize: function(options) {
+                this.application = options.application;
+                this.listenTo(wreqr.vent, "showModal", this.showModal);
+            },
+            showModal: function(modalView) {
+                // Global div for workaround with iframe resize and modals
+                var region = this.application.getRegion('sourcesModal');
+                var collectionRegion = this.application.getRegion('collectionRegion');
+                var iFrameModalDOM = $('#IframeModalDOM');
+                modalView.$el.on('hidden.bs.modal', function() {
+                    iFrameModalDOM.hide();
+                });
+                modalView.$el.on('shown.bs.modal', function() {
+                    var extraHeight = modalView.el.firstChild.clientHeight - collectionRegion.$el.height();
+                    if (extraHeight > 0) {
+                        iFrameModalDOM.height(extraHeight);
+                        iFrameModalDOM.show();
+                    }
+                });
+                region.show(modalView);
+                region.currentView.$el.modal();
+            }
+        });
+
+        SourceView.DeleteItem = Marionette.ItemView.extend({
+            template: "deleteSource"
+        });
+
+        SourceView.DeleteModal = Marionette.CompositeView.extend({
+            template: 'deleteModal',
+            className: 'modal',
+            itemView: SourceView.DeleteItem,
+            itemViewContainer: '.modal-body',
+            events: {
+                'click .submit-button': 'deleteSources',
+                'click .deleteSource': 'toggleChecks',
+                'click .selectSourceDelete': 'toggleChecks'
+            },
+            toggleChecks: function(e) {
+                var view = this;
+                var checked = e.target.checked;
+                // Loop through all the source views available to get the one relevant to the click.
+                // We don't want to go deleting/checking the wrong source/service.
+                var sourceView = view.children.find(function(childView) {
+                    return (childView.model.get("name") === e.target.value);
+                });
+
+                // Check to see if user clicked the source (top-level) checkbox or a service checkbox.
+                if (e.target.className === "deleteSource") {
+                    // If user clicked source checkbox, toggle all services underneath to match it.
+                    sourceView.$(".selectSourceDelete").each(function() {
+                        this.checked = checked;
+                    });
+                } else if (e.target.className === "selectSourceDelete") {
+                    // If user deselected a service checkbox, make sure to also deselect the source checkbox.
+                    if (!checked) {
+                        sourceView.$(".deleteSource")[0].checked = false;
+
+                        // Check to see if a user has manually selected all the services in a source, if they have,
+                        // also select the source checkbox.
+                    } else if (checked) {
+                        var allChecked = true;
+                        sourceView.$(".selectSourceDelete").each(function() {
+                            allChecked = allChecked && this.checked;
+                        });
+                        sourceView.$(".deleteSource")[0].checked = allChecked;
+                    }
+                }
+
+            },
+            deleteSources: function() {
+                var view = this;
+                var toDelete = [];
+                view.collection.each(function(item) {
+                    var currentConfig = item.get('currentConfiguration');
+                    var disableConfigs = item.get('disabledConfigurations');
+                    view.$(".selectSourceDelete").each(function(index, content) {
+                        if (content.checked) {
+
+                            var id = currentConfig ? currentConfig.get('id') : null;
+                            if (id === content.id) {
+                                toDelete.push(view.createDeletePromise(item, currentConfig));
+                            } else if (disableConfigs) {
+                                disableConfigs.each(function(disabledConfig) {
+                                    if (disabledConfig.get('id') === content.id) {
+                                        toDelete.push(view.createDeletePromise(item, disabledConfig));
+                                    }
+                                });
+                            }
                         }
                     });
-                    wreqr.vent.trigger('refreshSources');
-                    view.$el.modal("hide");
-                }).done();
+                });
+
+                //remove queued source configurations and entire source config if necessary
+                if (toDelete.length > 0) {
+                    //remove all selected configurations from the current item
+                    Q.all(toDelete).then(function(results) {
+                        _.each(results, function(result) {
+                            var item = result.source;
+                            if (item.size() <= 0) {
+                                //if no type configurations, delete the entire source.
+                                view.model.get('collection').removeSource(item);
+                                view.model.get('model').get('value').remove(item);
+                            }
+                        });
+                        wreqr.vent.trigger('refreshSources');
+                        view.$el.modal("hide");
+                    }).done();
+                }
+            },
+            createDeletePromise: function(source, config) {
+                var deferred = Q.defer();
+                var serviceModels = this.model.get('model').get('value');
+                config.destroy().success(function() {
+                    source.removeConfiguration(config);
+                    //sync up the service model so that the refresh updates properly
+                    serviceModels.remove(config.getService());
+                    deferred.resolve({
+                        source: source,
+                        config: config
+                    });
+                }).fail(function() {
+                    deferred.reject(new Error("Unable to delete configuration '" + source.get('name') + "'."));
+                });
+                return deferred.promise;
             }
-        },
-        createDeletePromise: function(source, config) {
-          var deferred = Q.defer();
-          var serviceModels = this.model.get('model').get('value');
-          config.destroy().success(function() {
-              source.removeConfiguration(config);
-              //sync up the service model so that the refresh updates properly
-              serviceModels.remove(config.getService());
-              deferred.resolve({
-                  source: source,
-                  config: config
-              });
-          }).fail(function() {
-              deferred.reject(new Error("Unable to delete configuration '" + source.get('name') + "'."));
-          });
-          return deferred.promise;
-        }
+        });
+
+        return SourceView;
+
     });
-
-    return SourceView;
-
-});

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/less/styles.less
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/less/styles.less
@@ -120,3 +120,59 @@ table.align-middle{
     vertical-align: middle;
   }
 }
+
+.accordion-title{
+    background-color: #eee;
+    color: #444;
+    cursor: pointer;
+    padding: 18px;
+    width: 100%;
+    border: none;
+    text-align: left;
+    outline: none;
+    font-size: 15px;
+    transition: 0.3s;
+}
+
+.accordion-title.active, .accordion-title:hover {
+    background-color: #ddd;
+
+
+}
+
+.accordion-content {
+    padding: 0 18px;
+    background-color: white;
+    max-height: 0;
+    overflow: hidden;
+    transition: 0.6s ease-in-out;
+    opacity: 0;
+}
+
+.accordion-content.show {
+    opacity: 1;
+    max-height: 500px;
+    overflow: auto;
+ }
+
+
+
+.accordion-title:after {
+    font-size: 13px;
+    color: #777;
+    float: right;
+    margin-left: 5px;
+}
+
+.add-configuration {
+    text-align: center;
+}
+
+.modal-organization {
+      padding-left: 18px;
+      padding-right: 18px;
+}
+
+.activeBindingSelect {
+    display: none;
+}

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/accordion.hbs
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/accordion.hbs
@@ -1,0 +1,5 @@
+<div class="accordion-title">
+    {{title}}
+    <span class="fa fa-chevron-down pull-right"></span>
+</div>
+<div class="accordion-content"></div>

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/bindingTitles.hbs
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/bindingTitles.hbs
@@ -1,0 +1,33 @@
+{{!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+ --}}
+<div class='{{id}} metatype control-group'>
+<label class='control-label' for='{{id}}'>{{name}}</label>
+{{#if description}}
+    <a href='#' class='description' data-title='{{id}}'>
+        <i class='glyphicon glyphicon-question-sign'></i>
+    </a>
+{{/if}}
+<div class="controls">
+    {{#if optionValues}}
+        <select id="{{id}}" name="{{id}}" class="form-control input-sm">
+            {{#each optionLabels}}
+                <option value="{{lookup ../optionValues @index}}" {{#is @index 0}}selected="selected" {{/is}}>{{.}}</option>
+            {{/each}}
+        </select>
+    {{else}}
+        <input type='text' class='{{id}} metatype form-control input-sm' name='{{id}}' id='{{id}}' value='{{#defaultValue}}{{.}}{{/defaultValue}}'>
+    {{/if}}
+</div>
+<p class='error-text help-block col-md-12'></p>
+</div>

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/optionLabelType.hbs
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/optionLabelType.hbs
@@ -11,17 +11,8 @@
  *
  **/
  --}}
-<table class='table table-striped align-middle'>
-    <thead>
-        <th class="name">Name</th>
-        <th class="active-binding">Active Binding</th>
-        <th class="status">Status</th>
-        <th class="type">Type</th>
-        <th><a href="#" class="addSourceLink fa fa-plus"></a></th>
-        <th><a href="#" class="removeSourceLink fa fa-trash-o"></a></th>
-        <th><a href="#" class="refreshButton fa fa-refresh"></a></th>
-    </thead>
-    <tbody>
-
-    </tbody>
-</table>
+{{#each list}}
+    <div class="accordion-title"></div>
+    <label value='{{id}}'>{{name}}</label>
+    <div class="accordion-content"></div>
+{{/each}}

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceModal.handlebars
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceModal.handlebars
@@ -11,18 +11,20 @@
  *
  **/
  --}}
- 
+
 <div class="modal-dialog">
     <div class="modal-content">
         <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
             <h4 class="modal-title">
                 {{#is mode 'edit'}}
-                    Edit {{name}}
+                    Edit:  {{name}}
                 {{else}}
                     Add Source
                 {{/is}}
             </h4>
+        </div>
+        <div class="modal-organization">
         </div>
         <div class="modal-body">
             <form class="form-horizontal add-federated-source container-fluid">
@@ -30,15 +32,28 @@
                     <div class="sourceName"></div>
                     <div class="bound-controls">
                         <div class="control-group">
-                            <label class="control-label">Source Type</label>
-                            <select class="form-control input-sm sourceTypesSelect"></select>
+
+                            <select class="form-control input-sm activeBindingSelect"></select>
+
                         </div>
+                        <label class="control-label2">Binding Configurations:</label>
                         <div class="modal-details"></div>
                     </div>
                 </fieldset>
             </form>
         </div>
-
+        <div class="modal-accordions">
+        </div>
+        {{#if isRegistry}}
+        <div id="checkboxes">
+            <label>Publish node to the following registries:</label>
+            <ul>
+                {{#each availableRegistries}}
+                    <li><input type="checkbox" value="{{this.name}}" {{#if this.alreadyPublishedTo}}checked{{/if}}> {{this.name}}</li>
+                {{/each}}
+            </ul>
+        </div>
+        {{/if}}
         <div class="modal-footer">
             <div class="btn-group">
                 {{#is mode 'edit'}}

--- a/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceOrganization.hbs
+++ b/catalog/admin/module/catalog-admin-module-sources/src/main/webapp/templates/sourceOrganization.hbs
@@ -11,17 +11,8 @@
  *
  **/
  --}}
-<table class='table table-striped align-middle'>
-    <thead>
-        <th class="name">Name</th>
-        <th class="active-binding">Active Binding</th>
-        <th class="status">Status</th>
-        <th class="type">Type</th>
-        <th><a href="#" class="addSourceLink fa fa-plus"></a></th>
-        <th><a href="#" class="removeSourceLink fa fa-trash-o"></a></th>
-        <th><a href="#" class="refreshButton fa fa-refresh"></a></th>
-    </thead>
-    <tbody>
-
-    </tbody>
-</table>
+<h4>Organization</h4>
+<h5>Name: {{name}}</h5>
+<h5>Address: {{address}}</h5>
+<h5>Phone Number: {{phoneNumber}}</h5>
+<h5>Email Address: {{emailAddress}}</h5>


### PR DESCRIPTION
What does this PR do?

This PR adds new functionality for the Source UI. This includes changes to the way sources are viewed on the main source page, adding accordion menus to the source modal popup, changing of various terms to better reflect their intended function, changes to the way sources are saved to the backend, and allowing users to publish nodes to configured registries.

Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@mcalcote @vinamartin @gordocanchola @ricklarsen @clockard

Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).

How should this be tested?

Install securely (dev=true) and with the correct hostname configured. Test federating with other users running the same build. Make sure nodes are added correctly with their corresponding values being saved. Check that nodes can be published to various registries and also seen from those registries.

Any background context you want to provide?

What are the relevant tickets?
DDF-1964

Screenshots (if appropriate)

Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
