### PR TITLE
DDF-2053 Update source creation from registry entries

### DIFF
--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -17,11 +17,16 @@
 
     <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
     <reference id="eventAdmin" interface="org.codice.ddf.parser.Parser" availability="mandatory"/>
-    <!--<reference id="federationAdminService" interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>-->
+    <reference id="federationAdminService" interface="org.codice.ddf.registry.federationadmin.service.FederationAdminService"/>
     <reference id="metaTypeService" interface="org.osgi.service.metatype.MetaTypeService" />
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)" availability="mandatory"/>
 
     <bean id="sourceConfigurationHandler" class="org.codice.ddf.registry.source.configuration.SourceConfigurationHandler" init-method="init">
+        <argument ref="federationAdminService"/>
+        <property name="configurationAdmin" ref="configurationAdmin"/>
+        <property name="metaTypeService" ref="metaTypeService"/>
+        <property name="parser" ref="xmlParser"/>
+
         <cm:managed-properties persistent-id="Registry_Configuration_Event_Handler" update-strategy="container-managed"/>
         <property name="urlBindingName" value="urlBindingName"/>
         <property name="bindingTypeFactoryPid">
@@ -39,10 +44,6 @@
                 <value>OpenSearch_1.0.0</value>
             </list>
         </property>
-
-        <property name="configurationAdmin" ref="configurationAdmin"/>
-        <property name="metaTypeService" ref="metaTypeService"/>
-        <property name="parser" ref="xmlParser"/>
     </bean>
 
     <service ref="sourceConfigurationHandler" interface="org.osgi.service.event.EventHandler">


### PR DESCRIPTION
#### What does this PR do?

When the metatype values are updated, adding a check for sourceActivated flag and priority order list being changed to get all registry metacards and update source configurations on them
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@clockard @mcalcote @vinamartin @brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
#### How should this be tested?

Verify the build
#### Any background context you want to provide?
#### What are the relevant tickets?

DDF-2053
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
  
  Adding federationAdminService
    On update of activate flag or the priority order list updateRegistryConfiguration will be run against all registry metacards
