### PR TITLE
DDF-2053 Update source creation from registry entries (Updated)

### DIFF
--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -36,7 +36,9 @@
                 <value>OpenSearch_1.0.0=OpenSearchSource</value>
             </list>
         </property>
-        <property name="activateSourceOnCreation" value="false"/>
+        <property name="preserveActiveConfigurations" value="true"/>
+        <property name="activateConfigurations" value="false"/>
+        <property name="cleanUpOnDelete" value="false"/>
         <property name="sourceActivationPriorityOrder">
             <list value-type="java.lang.String">
                 <value>CSW_2.0.2</value>

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/metatype/metatype.xml
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/resources/OSGI-INF/metatype/metatype.xml
@@ -27,9 +27,17 @@
             default="CSW_2.0.2=Csw_Federated_Source,WFS_1.0.0=Wfs_v1_0_0_Federated_Source,OpenSearch_1.0.0=OpenSearchSource"
             description="Key/Value mappings of binding type to factory PID"/>
 
-        <AD name="Activate Source on Creation" id="activateSourceOnCreation" required="true"
+        <AD name="Remove Configurations on Metacard Delete" id="cleanUpOnDelete" required="true"
             type="Boolean" default="false"
-            description="Flag used to determine if a source should be activated on creation"/>
+            description="Flag used to determine if configurations should be deleted when the metacard is deleted."/>
+
+        <AD name="Activate Configurations" id="activateConfigurations" required="true"
+            type="Boolean" default="false"
+            description="Flag used to determine if a configuration should be activated on creation"/>
+
+        <AD name="Preserve Active Configuration" id="preserveActiveConfigurations" required="true"
+            type="Boolean" default="true"
+            description="Flag used to determine if configurations should be preserved. If true will only allow auto activation on creation. If false auto activation will happen on updates as well. Only applicable if activateConfigurations is true."/>
 
         <AD name="Source Activation Priority Order" id="sourceActivationPriorityOrder" required="true" type="String" cardinality="100"
             default="CSW_2.0.2,WFS_1.0.0,OpenSearch_1.0.0" description="This is the priority list used to determine which source should be activated on creation"/>


### PR DESCRIPTION
#### What does this PR do?

Three flags were added to configure when configurations should be created or deleted automatically
The option of deleting configurations when a metacard is deleted was added.
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?

@mcalcote @clockard @vinamartin @brianfelix 
#### Choose 2 committers to review/merge the PR (please choose ONLY two committers from below, delete the rest).
#### How should this be tested?

verify build
#### Any background context you want to provide?
#### What are the relevant tickets?

DDF-2053
#### Screenshots (if appropriate)
#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
  Updating source configuration handler to auto activate or delete configurations and adding flags to metatype to configure when things should be automatic
  Renaming activateSourceOnCreation to activateConfigurations
    If this is set, configurations will be activated(according to prority order) on create or update of the metacards. Default is false
  Adding preserveActiveConfigurations
    If this is set, configuration will only be activated on create, not update of the metacards. Default is true
  Adding cleanUpOnDelete
    If this is set, configurations will be deleted when the metacard is deleted. Default is false;
  
    Adding delete event listener and method to delete configurations
