### PR TITLE
DDF-2057/DDF-2099 Update the remote registry UI so that it can set a remote registry name in addition to the local definition, Improve Test Coverage

### DIFF
--- a/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
+++ b/catalog/spatial/csw/spatial-csw-source-common/src/main/java/org/codice/ddf/spatial/ogc/csw/catalog/common/source/AbstractCswSource.java
@@ -1671,11 +1671,11 @@ public abstract class AbstractCswSource extends MaskableImpl
             // Simple "ping" to ensure the source is responding
             newAvailability = (getCapabilities() != null);
             if (oldAvailability != newAvailability) {
-                availabilityChanged(newAvailability);
                 // If the source becomes available, configure it.
                 if (newAvailability) {
                     configureCswSource();
                 }
+                availabilityChanged(newAvailability);
             }
             return newAvailability;
         }
@@ -1785,5 +1785,9 @@ public abstract class AbstractCswSource extends MaskableImpl
     public void setEventServiceAddress(String eventServiceAddress) {
         this.cswSourceConfiguration.setEventServiceAddress(eventServiceAddress);
 
+    }
+
+    protected void addSourceMonitor(SourceMonitor sourceMonitor) {
+        sourceMonitors.add(sourceMonitor);
     }
 }

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/RemoteStatus.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/RemoteStatus.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+/*global define*/
+define(['backbone'],
+function (Backbone) {
+    var RemoteStatus = {};
+    RemoteStatus.Model = Backbone.Model.extend({
+        url: "/jolokia/exec/org.codice.ddf.ui.admin.api.ConfigurationAdmin:service=ui,version=2.3.0/getProperties/",
+            model: RemoteStatus.Model,
+            initialize: function(pid) {
+                this.url += pid;
+            }
+        });
+    return RemoteStatus;
+});

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/Service.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/model/Service.js
@@ -92,59 +92,6 @@ define(function (require) {
             });
         },
 
-        makeEnableCall: function(){
-            var model = this;
-            var pid = model.get('id');
-            var url = [model.configUrl, "enableConfiguration", pid].join("/");
-            if (pid) {
-                return $.ajax({
-                    url: url,
-                    dataType: 'json'
-                }).done(function(){
-                    // massage some data to match the new backend pid.
-                    model.trigger('enabled');
-                    //enabling the model means the PID will be regenerated. This model no longer exists on the server.
-                    model.destroy();
-                }).fail(function(){
-                    new Error('Could not enable configuratoin ' + pid);
-                });
-            }
-
-            return $.Deferred().fail(new Error("Cannot enable since this model has no pid."));
-
-        },
-
-        makeDisableCall: function(){
-            var model = this;
-            var pid = model.get('id');
-            var url = [model.configUrl, "disableConfiguration", pid].join("/");
-            if (pid) {
-                return $.ajax({
-                    url: url,
-                    dataType: 'json'
-                }).done(function(){
-                    model.trigger('disabled');
-                    //disabling the model means the PID will be regenerated. This model no longer exists on the server.
-                    model.destroy();
-                }).fail(function(){
-                    new Error('Could not disable configuration ' + pid);
-                });
-            }
-
-            return $.Deferred().reject(new Error("Cannot enable since this model has no pid."));
-        },
-
-        // Used to make a call to the backend to disable the service that corresponds to the pid.
-        // Note: this does NOT affect the service the function is called on.
-        // Treat this as a static function
-        makeDisableCallByPid: function(pid){
-           var url = [this.configUrl, "disableConfiguration", pid].join("/");
-           return $.ajax({
-               url: url,
-               dataType: 'json'
-           });
-        },
-
         /**
          * When a model calls save the sync is called in Backbone.  I override it because this isn't a typical backbone
          * object
@@ -190,28 +137,6 @@ define(function (require) {
             }
             return deferred;
         },
-        createNewFromServer: function(deferred) {
-            var model = this,
-                addUrl = [model.configUrl, "add"].join("/");
-
-            model.makeConfigCall(model).done(function (data) {
-                var collect = model.collectedData(JSON.parse(data).value);
-                var jData = JSON.stringify(collect);
-
-                return $.ajax({
-                    type: 'POST',
-                    contentType: 'application/json',
-                    data: jData,
-                    url: addUrl
-                }).done(function (result) {
-                    deferred.resolve(result);
-                }).fail(function (error) {
-                    deferred.fail(error);
-                });
-            }).fail(function (error) {
-                deferred.fail(error);
-            });
-        },
         destroy: function() {
             var deferred = $.Deferred(),
                 model = this,
@@ -228,12 +153,6 @@ define(function (require) {
                 }).fail(function (error) {
                     deferred.fail(error);
                 });
-        },
-        initializeFromMSF: function(msf) {
-            this.set({"fpid":msf.get("id")});
-            this.set({"name":msf.get("name")});
-            this.get('properties').set({"service.factoryPid": msf.get("id")});
-            this.initializeFromService(msf);
         },
         initializeFromService: function(service) {
             var fpid = service.get('id');
@@ -306,12 +225,6 @@ define(function (require) {
                 return true;
             }
             return false;
-        },
-        initializeFromMSF: function(msf) {
-            this.set({"fpid":msf.get("id")});
-            this.set({"name":msf.get("name")});
-            this.initializeConfigurationFromMetatype(msf.get("metatype"));
-            this.configuration.set({"service.factoryPid": msf.get("id")});
         },
         initializeConfigurationFromMetatype: function(metatype) {
             var src = this;

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/view/Registry.view.js
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/js/view/Registry.view.js
@@ -53,17 +53,7 @@ function (ich,Marionette,_,$,Q,ModalRegistry,EmptyView,wreqr,Utils,deleteRegistr
             _.bindAll(this);
             this.listenTo(this.model, 'change', this.render);
             this.listenTo(wreqr.vent, 'status:update-'+ this.model.attributes.pid, this.updateStatus);
-
-        },
-        serializeData: function(){
-            var data = {};
-
-            data.name = this.model.get('name');
-            data.available = this.model.get('available');
-            data.allowPush = this.model.get('pushAllowed');
-            data.allowPull = this.model.get('pullAllowed');
-
-            return data;
+            this.listenTo(wreqr.vent, 'remoteStatus:update-'+ this.model.attributes.pid, this.updateRemoteStatus);
         },
         editRegistry: function(evt){
             evt.stopPropagation();
@@ -73,6 +63,12 @@ function (ich,Marionette,_,$,Q,ModalRegistry,EmptyView,wreqr,Utils,deleteRegistr
         updateStatus: function(status) {
             this.model.set('available', status.get('value'));
             this.render();
+        },
+        updateRemoteStatus: function(remoteStatus) {
+            if(remoteStatus.get('value')){
+                this.model.set('remoteName', remoteStatus.get('value').remoteName);
+                this.render();
+            }
         }
     });
 

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryList.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryList.handlebars
@@ -13,7 +13,8 @@
  --}}
 <table class='table table-striped align-middle'>
     <thead>
-        <th class="name">Name</th>
+        <th class="name">Local Name</th>
+        <th class="remote">Remote Name</th>
         <th class="status">Status</th>
         <th class="push">Allow Push</th>
         <th class="pull">Allow Pull</th>

--- a/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryRow.handlebars
+++ b/catalog/spatial/registry/registry-admin-modules/registry-admin-remote-ui/src/main/webapp/templates/registryRow.handlebars
@@ -25,6 +25,9 @@
     </div>
 </td>
 <td>
+    {{remoteName}}
+</td>
+<td>
     {{#if available}}
         <span class='label label-success'>Available</span>
     {{else}}
@@ -32,12 +35,12 @@
     {{/if}}
 </td>
 <td>
-    {{#if allowPush}}
+    {{#if pushAllowed}}
         <span class="fa fa-check"></span>
     {{/if}}
 </td>
 <td colspan="4">
-    {{#if allowPull}}
+    {{#if pullAllowed}}
         <span class="fa fa-check"></span>
     {{/if}}
 </td>

--- a/catalog/spatial/registry/registry-api-impl/pom.xml
+++ b/catalog/spatial/registry/registry-api-impl/pom.xml
@@ -241,22 +241,22 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.82</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.50</minimum>
+                                            <minimum>0.60</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.44</minimum>
+                                            <minimum>0.51</minimum>
                                         </limit>
                                         <limit>
                                             <counter>LINE</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.75</minimum>
+                                            <minimum>0.82</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-api-impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -32,6 +32,8 @@
     <reference id="xmlParser" interface="org.codice.ddf.parser.Parser" filter="(id=xml)"
                availability="mandatory"/>
 
+    <reference id="configurationAdmin" interface="org.osgi.service.cm.ConfigurationAdmin"/>
+
     <bean id="metacardTypes" class="ddf.catalog.util.impl.SortedServiceList"/>
     <reference-list id="metacardTypeList" interface="ddf.catalog.data.MetacardType">
         <reference-listener ref="metacardTypes" bind-method="bindPlugin"
@@ -101,6 +103,8 @@
             <property name="parser" ref="xmlParser"/>
             <property name="pullAllowed" value="true"/>
             <property name="pushAllowed" value="true"/>
+            <property name="configAdmin" ref="configurationAdmin"/>
+            <property name="registryId" value=""/>
             <cm:managed-properties persistent-id="" update-strategy="component-managed"
                                    update-method="refresh"/>
         </cm:managed-component>

--- a/catalog/spatial/registry/registry-api/src/main/java/org/codice/ddf/registry/api/RegistryStore.java
+++ b/catalog/spatial/registry/registry-api/src/main/java/org/codice/ddf/registry/api/RegistryStore.java
@@ -32,4 +32,10 @@ public interface RegistryStore extends CatalogStore, ConfiguredService {
      * @return true if allowed otherwise false
      */
     boolean isPullAllowed();
+
+    /**
+     * Indicates the Id associated with this registry
+     * @return registry id in a string
+     */
+    String getRegistryId();
 }

--- a/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
+++ b/catalog/spatial/registry/registry-federation-admin-service-impl/src/main/java/org/codice/ddf/registry/federationadmin/service/impl/FederationAdminServiceImpl.java
@@ -78,7 +78,6 @@ import ddf.catalog.filter.FilterBuilder;
 import ddf.catalog.operation.CreateRequest;
 import ddf.catalog.operation.CreateResponse;
 import ddf.catalog.operation.DeleteRequest;
-import ddf.catalog.operation.Query;
 import ddf.catalog.operation.QueryRequest;
 import ddf.catalog.operation.QueryResponse;
 import ddf.catalog.operation.UpdateRequest;
@@ -105,6 +104,8 @@ public class FederationAdminServiceImpl implements FederationAdminService {
     private static final Logger LOGGER = LoggerFactory.getLogger(FederationAdminServiceImpl.class);
 
     private static final FilterFactory FILTER_FACTORY = new FilterFactoryImpl();
+
+    private static final int PAGE_SIZE = 1000;
 
     private CatalogFramework catalogFramework;
 
@@ -568,7 +569,8 @@ public class FederationAdminServiceImpl implements FederationAdminService {
                         FILTER_FACTORY.like(FILTER_FACTORY.property(Metacard.TAGS),
                                 RegistryConstants.REGISTRY_TAG));
 
-        Query query = new QueryImpl(filter);
+        QueryImpl query = new QueryImpl(filter);
+        query.setPageSize(PAGE_SIZE);
         QueryRequest queryRequest = new QueryRequestImpl(query, sourceIds);
 
         Subject systemSubject = security.getSystemSubject();
@@ -854,8 +856,9 @@ public class FederationAdminServiceImpl implements FederationAdminService {
 
         SortBy sortBy = FILTER_FACTORY.sort(Metacard.CREATED, SortOrder.ASCENDING);
 
-        Query query = new QueryImpl(filter);
-        ((QueryImpl) query).setSortBy(sortBy);
+        QueryImpl query = new QueryImpl(filter);
+        query.setSortBy(sortBy);
+        query.setPageSize(PAGE_SIZE);
 
         Subject systemSubject = security.getSystemSubject();
         QueryRequest queryRequest = new QueryRequestImpl(query, sourceIds);

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
@@ -330,7 +330,9 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
                 .text(RegistryConstants.REGISTRY_TAG);
         Subject systemSubject = Security.getInstance()
                 .getSystemSubject();
-        QueryRequest request = new QueryRequestImpl(new QueryImpl(registryFilter));
+        QueryImpl query = new QueryImpl(registryFilter);
+        query.setPageSize(1000);
+        QueryRequest request = new QueryRequestImpl(query);
         request.getProperties()
                 .put(SecurityConstants.SECURITY_SUBJECT, systemSubject);
 

--- a/catalog/spatial/registry/registry-report-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/catalog/spatial/registry/registry-report-action-provider/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -16,12 +16,12 @@
 
     <bean id="registryActionProvider"
           class="org.codice.ddf.registry.report.action.provider.RegistryMetacardActionProvider">
-        <argument value="catalog.data.metacard.view"/>
+        <argument value="catalog.data.registry.view"/>
     </bean>
 
     <service ref="registryActionProvider" interface="ddf.action.ActionProvider">
         <service-properties>
-            <entry key="id" value="catalog.data.metacard.view"/>
+            <entry key="id" value="catalog.data.registry.view"/>
         </service-properties>
     </service>
 

--- a/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
+++ b/distribution/test/itests/test-itests-ddf/src/test/java/ddf/test/itests/catalog/TestRegistry.java
@@ -79,6 +79,25 @@ public class TestRegistry extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testCswRegistryUpdateFailure() throws Exception {
+        String id = createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51280");
+
+        Response response = given().body(Library.getCswRegistryUpdate()
+                .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
+                        "urn:uuid:2014ca7f59ac46f495e32b4a67a51280")
+                .replace("Node Name", "New Node Name")
+                .replaceAll("someUUID", id))
+                .header("Content-Type", "text/xml")
+                .expect()
+                .log()
+                .all()
+                .statusCode(400)
+                .when()
+                .post(CSW_PATH.getUrl());
+        ValidatableResponse validatableResponse = response.then();
+    }
+
+    @Test
     public void testCswRegistryUpdate() throws Exception {
         String id = createRegistryEntry("urn:uuid:2014ca7f59ac46f495e32b4a67a51280");
 
@@ -86,6 +105,7 @@ public class TestRegistry extends AbstractIntegrationTest {
                 .replaceAll("urn:uuid:2014ca7f59ac46f495e32b4a67a51276",
                         "urn:uuid:2014ca7f59ac46f495e32b4a67a51280")
                 .replace("Node Name", "New Node Name")
+                .replace("2016-01-26T17:16:34.996Z", "2018-02-26T17:16:34.996Z")
                 .replaceAll("someUUID", id))
                 .header("Content-Type", "text/xml")
                 .expect()


### PR DESCRIPTION
@vinamartin @clockard @gordocanchola @brianfelix 
DDF-2057 Update the remote registry UI so that it can set a remote registry name in addition to the local definition
DDF-2099 Update registry-api-impl unit tests
#### How should this be tested?

Test UI, build
