### PR TITLE
DDF-2128 Update RegistryConstants to include additional strings used in multiple places

### DIFF
--- a/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/RegistryConstants.java
+++ b/catalog/spatial/registry/registry-common/src/main/java/org/codice/ddf/registry/common/RegistryConstants.java
@@ -50,4 +50,8 @@ public class RegistryConstants {
 
     public static final String GUID_PREFIX = "urn:uuid:";
 
+    public static final String BINDING_TYPE = "bindingType";
+
+    public static final String METACARD_PROPERTY= "ddf.catalog.event.metacard";
+
 }

--- a/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
+++ b/catalog/spatial/registry/registry-identification-plugin/src/main/java/org/codice/ddf/registry/identification/IdentificationPlugin.java
@@ -92,16 +92,6 @@ public class IdentificationPlugin implements PreIngestPlugin, PostIngestPlugin {
 
     private Set<String> registryIds = ConcurrentHashMap.newKeySet();
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(IdentificationPlugin.class);
-
-    private static final String BINDING_TYPE = "bindingType";
-
-    private static final String DISABLED_CONFIGURATION_SUFFIX = "_disabled";
-
-    private static final String ID = "id";
-
-    private static final String SHORTNAME = "shortname";
-
     @Override
     public CreateRequest process(CreateRequest input)
             throws PluginExecutionException, StopProcessingException {

--- a/catalog/spatial/registry/registry-publication-update-handler/src/main/java/org/codice/ddf/registry/publication/RegistryPublicationHandler.java
+++ b/catalog/spatial/registry/registry-publication-update-handler/src/main/java/org/codice/ddf/registry/publication/RegistryPublicationHandler.java
@@ -38,8 +38,6 @@ public class RegistryPublicationHandler implements EventHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RegistryPublicationHandler.class);
 
-    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
-
     private FederationAdminService adminService;
 
     private ExecutorService executor;
@@ -66,7 +64,7 @@ public class RegistryPublicationHandler implements EventHandler {
 
     @Override
     public void handleEvent(Event event) {
-        Metacard mcard = (Metacard) event.getProperty(METACARD_PROPERTY);
+        Metacard mcard = (Metacard) event.getProperty(RegistryConstants.METACARD_PROPERTY);
         if (mcard == null) {
             return;
         }

--- a/catalog/spatial/registry/registry-report-viewer/src/main/java/org.codice.ddf.registry.report.viewer/RegistryReportViewer.java
+++ b/catalog/spatial/registry/registry-report-viewer/src/main/java/org.codice.ddf.registry.report.viewer/RegistryReportViewer.java
@@ -62,8 +62,6 @@ public class RegistryReportViewer {
 
     private String registryName = "";
 
-    private static final String BINDING_TYPE = "bindingType";
-
     private FederationAdminService federationAdminService;
 
     private ClassPathTemplateLoader templateLoader;
@@ -159,13 +157,13 @@ public class RegistryReportViewer {
                     Map<String, Object> bindingProperties;
                     String bindingType;
                     bindingProperties = getCustomSlots(binding.getSlot());
-                    if (!bindingProperties.containsKey(BINDING_TYPE) || bindingProperties.get(
-                            BINDING_TYPE) == null) {
+                    if (!bindingProperties.containsKey(RegistryConstants.BINDING_TYPE) || bindingProperties.get(
+                            RegistryConstants.BINDING_TYPE) == null) {
                         continue;
                     }
-                    bindingType = bindingProperties.get(BINDING_TYPE)
+                    bindingType = bindingProperties.get(RegistryConstants.BINDING_TYPE)
                             .toString();
-                    bindingProperties.remove(BINDING_TYPE);
+                    bindingProperties.remove(RegistryConstants.BINDING_TYPE);
                     serviceProperties.put(bindingType, bindingProperties);
                 }
                 serviceInfo.put(serviceName, serviceProperties);

--- a/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
+++ b/catalog/spatial/registry/registry-source-configuration-handler/src/main/java/org/codice/ddf/registry/source/configuration/SourceConfigurationHandler.java
@@ -68,10 +68,6 @@ public class SourceConfigurationHandler implements EventHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceConfigurationHandler.class);
 
-    private static final String METACARD_PROPERTY = "ddf.catalog.event.metacard";
-
-    private static final String BINDING_TYPE = "bindingType";
-
     private static final String DISABLED_CONFIGURATION_SUFFIX = "_disabled";
 
     private static final String ID = "id";
@@ -121,7 +117,7 @@ public class SourceConfigurationHandler implements EventHandler {
     @Override
     public void handleEvent(Event event) {
         LOGGER.debug("Received event");
-        Metacard mcard = (Metacard) event.getProperty(METACARD_PROPERTY);
+        Metacard mcard = (Metacard) event.getProperty(RegistryConstants.METACARD_PROPERTY);
         if (mcard == null) {
             return;
         }
@@ -272,15 +268,15 @@ public class SourceConfigurationHandler implements EventHandler {
 
             Hashtable<String, Object> serviceConfigurationProperties = new Hashtable<>();
 
-            if (slotMap.get(BINDING_TYPE) == null
+            if (slotMap.get(RegistryConstants.BINDING_TYPE) == null
                     || CollectionUtils.isEmpty(RegistryPackageUtils.getSlotStringValues(slotMap.get(
-                    BINDING_TYPE)
+                    RegistryConstants.BINDING_TYPE)
                     .get(0)))) {
                 continue;
             }
 
             String factoryPidMask = RegistryPackageUtils.getSlotStringValues(slotMap.get(
-                    BINDING_TYPE)
+                    RegistryConstants.BINDING_TYPE)
                     .get(0))
                     .get(0);
             String factoryPid = bindingTypeToFactoryPidMap.get(factoryPidMask);
@@ -393,15 +389,15 @@ public class SourceConfigurationHandler implements EventHandler {
             Map<String, List<SlotType1>> slotMap =
                     RegistryPackageUtils.getNameSlotMapDuplicateSlotNamesAllowed(bindingType.getSlot());
 
-            if (slotMap.get(BINDING_TYPE) == null
+            if (slotMap.get(RegistryConstants.BINDING_TYPE) == null
                     || CollectionUtils.isEmpty(RegistryPackageUtils.getSlotStringValues(slotMap.get(
-                    BINDING_TYPE)
+                    RegistryConstants.BINDING_TYPE)
                     .get(0)))) {
                 continue;
             }
 
             String factoryPidMask = RegistryPackageUtils.getSlotStringValues(slotMap.get(
-                    BINDING_TYPE)
+                    RegistryConstants.BINDING_TYPE)
                     .get(0))
                     .get(0);
 


### PR DESCRIPTION
#### What does this PR do?
RegistryConstants was updated to included two more constants that are common through a few of the registry files. 
#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged; if a component team is listed, at least one of its members needs to approve)?
@gordocanchola 
@brianfelix 
@mcalcote 
@clockard 
@vinamartin 
#### How should this be tested?
By checking the consistency of the constants. 
#### Any background context you want to provide?
While going through some of the files, I noticed some of the constants went unused. I noticed 2 were unused in RegistryConstants and 5 were unused in the IdentificationPlugin. 

Also, there are some string literals that can be converted into constants, but I wanted to run it through someone before I start implementing them. For now, I just focused on the existing constants. 

#### What are the relevant tickets?
Added as a ticket that relates to DIB-4407 

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
